### PR TITLE
refactor to share context stack

### DIFF
--- a/util/ctxutil/ctx_util.go
+++ b/util/ctxutil/ctx_util.go
@@ -1,0 +1,24 @@
+package ctxutil
+
+import (
+	"context"
+
+	elog "github.com/eluv-io/log-go"
+)
+
+var log = elog.Get("/eluvio/util/ctxutil")
+
+var current = NewStack()
+
+func Current() ContextStack {
+	return current
+}
+
+func SetCurrent(c ContextStack) {
+	current = c
+}
+
+// Ctx returns the current context.
+func Ctx() context.Context {
+	return current.Ctx()
+}

--- a/util/ctxutil/stack.go
+++ b/util/ctxutil/stack.go
@@ -5,13 +5,10 @@ import (
 	"runtime/debug"
 	"sync"
 
-	elog "github.com/eluv-io/log-go"
 	"go.opentelemetry.io/otel/api/trace"
 
 	"github.com/eluv-io/common-go/util/goutil"
 )
-
-var log = elog.Get("/eluvio/util/ctxutil")
 
 // NewStack creates a new ContextStack.
 func NewStack() ContextStack {

--- a/util/ioutil/bytes_count.go
+++ b/util/ioutil/bytes_count.go
@@ -1,0 +1,26 @@
+package ioutil
+
+import "io"
+
+var _ io.ReadCloser = (*BytesCountReader)(nil)
+
+// BytesCountReader is a wrapper around an io.Reader that counts bytes read
+type BytesCountReader struct {
+	io.Reader
+	BytesCount uint64
+}
+
+func (b *BytesCountReader) Read(p []byte) (int, error) {
+	n, err := b.Reader.Read(p)
+	if n > 0 {
+		b.BytesCount += uint64(n)
+	}
+	return n, err
+}
+
+func (b *BytesCountReader) Close() error {
+	if cl, ok := b.Reader.(io.Closer); ok {
+		return cl.Close()
+	}
+	return nil
+}

--- a/util/ioutil/bytes_count_test.go
+++ b/util/ioutil/bytes_count_test.go
@@ -1,0 +1,28 @@
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBytesCount(t *testing.T) {
+	buf := make([]byte, 1234)
+	bc := &BytesCountReader{
+		Reader: bytes.NewReader(buf),
+	}
+
+	n, err := bc.Read(make([]byte, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, uint64(1), bc.BytesCount)
+
+	n, err = bc.Read(make([]byte, 2048))
+	require.Equal(t, 1233, n)
+	require.Equal(t, uint64(1234), bc.BytesCount)
+
+	_, err = bc.Read(make([]byte, 1))
+	require.Equal(t, io.EOF, err)
+}

--- a/util/ioutil/discard.go
+++ b/util/ioutil/discard.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// Discard is an Writer on which all Write calls succeed without doing anything.
+// Discard is a Writer on which all Write calls succeed without doing anything.
 // Discard is like io.Discard but reports the count of written bytes
 type Discard struct {
 	BytesCount int64


### PR DESCRIPTION
These changes are intended to go with [content-fabric/#2121](qluvio/content-fabric/#2121)(use context stack for usage reporting)

* move global context stack from traceutil to ctxutil
* add BytesCountReader
 