### PR TITLE
Add ed25519 ids and doc for ikey

### DIFF
--- a/format/id/id.go
+++ b/format/id/id.go
@@ -57,6 +57,7 @@ const (
 	Tenant
 	Group
 	Key
+	Ed25519
 )
 
 const codeLen = 1
@@ -79,7 +80,8 @@ var prefixToCode = map[string]Code{
 	"icrs": CachedResultSet,
 	"iten": Tenant,
 	"igrp": Group,
-	"ikey": Key,
+	"ikey": Key,     // last 20 bytes of the keccak256 of a bls381 ecp
+	"ied2": Ed25519, // 32 byte ed25519 public key
 }
 var codeToName = map[Code]string{
 	UNKNOWN:         "unknown",
@@ -98,6 +100,7 @@ var codeToName = map[Code]string{
 	Tenant:          "tenant",
 	Group:           "group",
 	Key:             "key",
+	Ed25519:         "ed25519 public key",
 }
 
 func init() {


### PR DESCRIPTION
Add an ID type for ed25519 keys that will be used to interact with Solana (e.g. the oracle of the crypto p2p payments infra).