### PR TITLE
Fix div by 0 on empty histogram

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,4 +69,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/modern-go/gls => github.com/eluv-io/gls v0.0.0-20240109172027-f54afc64be57
+replace github.com/modern-go/gls => github.com/eluv-io/gls v1.0.0-elv1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/eluv-io/apexlog-go v1.9.1-elv4 h1:lJE8+Y+GtUhw1BBAlFePuVZg78jCKgeFsdq
 github.com/eluv-io/apexlog-go v1.9.1-elv4/go.mod h1:pZhIuRbWTsOm5WEOxke9B2dczjQuaEGeJXEYd5lCxkk=
 github.com/eluv-io/errors-go v1.0.3 h1:sROm5+5xA2oMDUq5T69CVI2w2W5JDCr8QakysjiCPX4=
 github.com/eluv-io/errors-go v1.0.3/go.mod h1:SoBNolWeyjrvHosBsIpxlQAq5/jVvqWsw/o0XpGMtKU=
-github.com/eluv-io/gls v0.0.0-20240109172027-f54afc64be57 h1:3Xd2e2/khksl5KohJGnrLS/+rYptG/+yhjHrNvXqzQE=
-github.com/eluv-io/gls v0.0.0-20240109172027-f54afc64be57/go.mod h1:4rPCrom1ZvL5sqFMGiNbCr/QfDq3oljqXEBdstdge0o=
+github.com/eluv-io/gls v1.0.0-elv1 h1:fV9z/aLSs5KH8wWMkamoS/Xxl8wmXF76WMx8/N5XEr8=
+github.com/eluv-io/gls v1.0.0-elv1/go.mod h1:4rPCrom1ZvL5sqFMGiNbCr/QfDq3oljqXEBdstdge0o=
 github.com/eluv-io/inject-go v1.0.2 h1:1+t2LqRHk1Ns+2JUBN9dqATxa6Y+7ay7GftfJVXqfT0=
 github.com/eluv-io/inject-go v1.0.2/go.mod h1:03/vIoB3v+J0ASXrdw7nes2Qc2MeY9BKYf2BWJCJf3M=
 github.com/eluv-io/log-go v1.0.4 h1:WQwaoCN4lNfzS6qvhdlzUbKv2ZTDmE/Z855nMLZri10=

--- a/util/histogram/histogram.go
+++ b/util/histogram/histogram.go
@@ -324,7 +324,7 @@ func (h *DurationHistogram) Quantile(q float64) time.Duration {
 			if h.bins[i].Max != 0 {
 				binSpan = h.bins[i].Max - binStart
 			} else {
-				binAvg := float64(h.bins[i].DSum) / float64(h.bins[i].Count)
+				binAvg := float64(h.bins[i].DSum) / fData
 				binSpan = (time.Duration(binAvg) - binStart) * 2
 			}
 			return binStart + time.Duration(int64(binProportion*float64(binSpan)))

--- a/util/histogram/histogram_test.go
+++ b/util/histogram/histogram_test.go
@@ -207,10 +207,11 @@ func TestStandardDeviation2(t *testing.T) {
 		{Label: "750ms-1s", Count: 781, DSum: 665865316657},
 		{Label: "1s-2s", Count: 328, DSum: 389033374409},
 		{Label: "2s-4s", Count: 2, DSum: 4031693641},
-		{Label: "4s-", Count: 0, DSum: 0},
+		{Label: "4s-10s", Count: 0, DSum: 0},
 	}
 	h := NewDurationHistogram(SegmentLatencyHistogram)
-	h.LoadValues(values)
+	err := h.LoadValues(values)
+	require.NoError(t, err)
 
 	require.Equal(t, int64(196), h.StandardDeviation().Milliseconds())
 }
@@ -290,7 +291,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	var vals []*SerializedDurationBin
-	json.Unmarshal(s, &vals)
+	err = json.Unmarshal(s, &vals)
+	require.NoError(t, err)
 	h2 := NewDurationHistogram(DefaultDurationHistogram)
 	err = h2.LoadValues(vals)
 	require.NoError(t, err)


### PR DESCRIPTION
This manifested in int64(NaN), which is UB in golang. Anecdotally, it is 0 on M1 and -inf on linux.