### PR TITLE
Slow request tracing

### DIFF
--- a/util/ctxutil/noop.go
+++ b/util/ctxutil/noop.go
@@ -38,14 +38,6 @@ func (n noop) StartSpan(_ string) trace.Span {
 	return trace.NoopSpan{}
 }
 
-func (n noop) StartSlowSpan(_ string) trace.Span {
-	return trace.NoopSpan{}
-}
-
 func (n noop) Span() trace.Span {
-	return trace.NoopSpan{}
-}
-
-func (n noop) SlowSpan() trace.Span {
 	return trace.NoopSpan{}
 }

--- a/util/ctxutil/noop.go
+++ b/util/ctxutil/noop.go
@@ -30,7 +30,7 @@ func (n noop) Go(fn func()) {
 	go fn()
 }
 
-func (n noop) InitTracing(_ string) trace.Span {
+func (n noop) InitTracing(_ string, slowOnly bool) trace.Span {
 	return trace.NoopSpan{}
 }
 
@@ -38,6 +38,14 @@ func (n noop) StartSpan(_ string) trace.Span {
 	return trace.NoopSpan{}
 }
 
+func (n noop) StartSlowSpan(_ string) trace.Span {
+	return trace.NoopSpan{}
+}
+
 func (n noop) Span() trace.Span {
+	return trace.NoopSpan{}
+}
+
+func (n noop) SlowSpan() trace.Span {
 	return trace.NoopSpan{}
 }

--- a/util/ctxutil/noop.go
+++ b/util/ctxutil/noop.go
@@ -38,6 +38,10 @@ func (n noop) StartSpan(_ string) trace.Span {
 	return trace.NoopSpan{}
 }
 
+func (n noop) SubSpan(_ trace.Span, _ string) func() {
+	return func() {}
+}
+
 func (n noop) Span() trace.Span {
 	return trace.NoopSpan{}
 }

--- a/util/ctxutil/stack.go
+++ b/util/ctxutil/stack.go
@@ -3,6 +3,7 @@ package ctxutil
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"runtime/debug"
 	"sync"
 
@@ -133,6 +134,8 @@ func (c *contextStack) Push(ctx context.Context) func() {
 		parent: se.stack,
 	}
 	se.stack = s
+	gid := goutil.GoID()
+	log.Info(fmt.Sprintf("NATE push GID %d", gid), "stack", string(debug.Stack()))
 	return func() {
 		c.pop(s)
 	}
@@ -145,6 +148,8 @@ func (c *contextStack) pop(expect *stack) {
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
+
+	log.Info(fmt.Sprintf("NATE pop GID %d", gid), "stack", string(debug.Stack()))
 
 	e, ok := c.stacks[gid]
 	if !ok {

--- a/util/ctxutil/stack.go
+++ b/util/ctxutil/stack.go
@@ -3,7 +3,6 @@ package ctxutil
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"runtime/debug"
 	"sync"
 
@@ -134,8 +133,6 @@ func (c *contextStack) Push(ctx context.Context) func() {
 		parent: se.stack,
 	}
 	se.stack = s
-	gid := goutil.GoID()
-	log.Info(fmt.Sprintf("NATE push GID %d", gid), "stack", string(debug.Stack()))
 	return func() {
 		c.pop(s)
 	}
@@ -148,8 +145,6 @@ func (c *contextStack) pop(expect *stack) {
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-
-	log.Info(fmt.Sprintf("NATE pop GID %d", gid), "stack", string(debug.Stack()))
 
 	e, ok := c.stacks[gid]
 	if !ok {

--- a/util/ctxutil/stack.go
+++ b/util/ctxutil/stack.go
@@ -94,9 +94,8 @@ type ContextStack interface {
 	//	defer span.End()
 	StartSpan(spanName string) trace.Span
 
-	// SubSpan creates a new sub span of the given parent span and pushes its context onto the stack
-	// of the current goroutine. Defer-call the returned function to end the span and pop the
-	// context.
+	// SubSpan creates a new sub span of the given parent span and pushes its context onto the
+	// stack. Defer-call the returned function to end the span and pop the context.
 	SubSpan(parent trace.Span, spanName string) (release func())
 
 	// Span retrieves the goroutine's current span.
@@ -205,9 +204,8 @@ func (c *contextStack) StartSpan(spanName string) trace.Span {
 }
 
 func (c *contextStack) SubSpan(parent trace.Span, spanName string) (release func()) {
-	ctx := Current()
-	spCtx, sp := parent.Start(ctx.Ctx(), spanName)
-	pop := ctx.Push(spCtx)
+	spCtx, sp := parent.Start(c.Ctx(), spanName)
+	pop := c.Push(spCtx)
 	return func() {
 		sp.End()
 		pop()

--- a/util/ctxutil/stack_test.go
+++ b/util/ctxutil/stack_test.go
@@ -24,7 +24,7 @@ func TestContextStack(t *testing.T) {
 func TestContextStackTracing(t *testing.T) {
 	stack := ctxutil.NewStack()
 
-	span := stack.InitTracing("test-span")
+	span := stack.InitTracing("test-span", false)
 
 	obj := anObjectWithTracing{cs: stack}
 	obj.A()

--- a/util/ctxutil/stack_test.go
+++ b/util/ctxutil/stack_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/eluv-io/apexlog-go/handlers/memory"
 	"github.com/eluv-io/common-go/util/ctxutil"
 	"github.com/eluv-io/common-go/util/jsonutil"
+	"github.com/eluv-io/common-go/util/traceutil"
 	"github.com/eluv-io/common-go/util/traceutil/trace"
 	"github.com/eluv-io/log-go"
 )
@@ -40,6 +41,34 @@ func TestContextStackTracing(t *testing.T) {
 	require.Equal(t, 13, strings.Count(trc, "name"))
 	require.Equal(t, 13, strings.Count(trc, "time"))
 	require.Contains(t, trc, `"current-func":"C"`)
+}
+
+func TestContextStackSubspan(t *testing.T) {
+
+	rootSp := traceutil.InitTracing("test-span", false)
+
+	wg := sync.WaitGroup{}
+
+	fUsingRootSp := func() {
+		defer wg.Done()
+		release := ctxutil.Current().SubSpan(rootSp, "sub-span")
+		defer release()
+
+		subSp := traceutil.StartSpan("sub-span-2")
+		subSp.Attribute("key", "val")
+		subSp.End()
+	}
+
+	wg.Add(1)
+	go fUsingRootSp()
+	wg.Wait()
+
+	rootSp.End()
+	trc := rootSp.Json()
+
+	require.Contains(t, trc, `"sub-span"`)
+	require.Contains(t, trc, `"sub-span-2"`)
+	require.Contains(t, trc, `"attr":{"key":"val"}`)
 }
 
 func TestContextStackTracingDisabled(t *testing.T) {

--- a/util/traceutil/trace/context.go
+++ b/util/traceutil/trace/context.go
@@ -3,8 +3,10 @@ package trace
 import "context"
 
 type contextKey struct{}
+type slowContextKey struct{}
 
 var activeSpanKey = contextKey{}
+var slowSpanKey = slowContextKey{}
 
 // StartRootSpan starts a new top-level span and registers it with the given context.
 func StartRootSpan(ctx context.Context, name string) (context.Context, Span) {
@@ -12,15 +14,44 @@ func StartRootSpan(ctx context.Context, name string) (context.Context, Span) {
 	return ContextWithSpan(ctx, sub), sub
 }
 
+// StartSlowSpan starts a new top-level slow span and registers it with the given context.
+func StartSlowSpan(ctx context.Context, name string) (context.Context, Span) {
+	sub := newSpan(name)
+	return ContextWithSlowSpan(ctx, sub), sub
+}
+
 // ContextWithSpan returns a new `context.Context` that holds a reference to the provided `span`.
 func ContextWithSpan(ctx context.Context, span Span) context.Context {
 	return context.WithValue(ctx, activeSpanKey, span)
+}
+
+// ContextWithSlowSpan returns a new `context.Context` that holds a reference to the provided `span`
+// as the designated 'slow span'.
+func ContextWithSlowSpan(ctx context.Context, span Span) context.Context {
+	return context.WithValue(ctx, slowSpanKey, span)
 }
 
 // SpanFromContext returns the `Span` previously associated with `ctx`, or a no-op span if none is found.
 func SpanFromContext(ctx context.Context) Span {
 	val := ctx.Value(activeSpanKey)
 	if sp, ok := val.(Span); ok {
+		return sp
+	}
+	return NoopSpan{}
+}
+
+// SpanFromContext returns the `Span` that should be use for tracking slow requests.
+//
+// If full tracing is enabled, that will be the span returned. Otherwise, it will return the span
+// specifically for slow requests. If neither is found, it will return a no-op span. The no-op span
+// should generally never actually be returned, however.
+func SlowSpanFromContext(ctx context.Context) Span {
+	val := ctx.Value(activeSpanKey)
+	if sp, ok := val.(Span); ok {
+		return sp
+	}
+	valSlow := ctx.Value(slowSpanKey)
+	if sp, ok := valSlow.(Span); ok {
 		return sp
 	}
 	return NoopSpan{}

--- a/util/traceutil/trace/context.go
+++ b/util/traceutil/trace/context.go
@@ -40,19 +40,20 @@ func SpanFromContext(ctx context.Context) Span {
 	return NoopSpan{}
 }
 
-// SpanFromContext returns the `Span` that should be use for tracking slow requests.
+// SpanFromContext returns the `Span` that should be use for tracking slow requests, and if the
+// returned span should be used only for slow requests.
 //
 // If full tracing is enabled, that will be the span returned. Otherwise, it will return the span
 // specifically for slow requests. If neither is found, it will return a no-op span. The no-op span
 // should generally never actually be returned, however.
-func SlowSpanFromContext(ctx context.Context) Span {
+func SlowSpanFromContext(ctx context.Context) (Span, bool) {
 	val := ctx.Value(activeSpanKey)
 	if sp, ok := val.(Span); ok && sp.IsRecording() {
-		return sp
+		return sp, false
 	}
 	valSlow := ctx.Value(slowSpanKey)
 	if sp, ok := valSlow.(Span); ok {
-		return sp
+		return sp, true
 	}
-	return NoopSpan{}
+	return NoopSpan{}, false
 }

--- a/util/traceutil/trace/context.go
+++ b/util/traceutil/trace/context.go
@@ -3,32 +3,24 @@ package trace
 import "context"
 
 type contextKey struct{}
-type slowContextKey struct{}
 
 var activeSpanKey = contextKey{}
-var slowSpanKey = slowContextKey{}
 
 // StartRootSpan starts a new top-level span and registers it with the given context.
 func StartRootSpan(ctx context.Context, name string) (context.Context, Span) {
-	sub := newSpan(name)
+	sub := newSpan(name, false)
 	return ContextWithSpan(ctx, sub), sub
 }
 
 // StartSlowSpan starts a new top-level slow span and registers it with the given context.
 func StartSlowSpan(ctx context.Context, name string) (context.Context, Span) {
-	sub := newSpan(name)
-	return ContextWithSlowSpan(ctx, sub), sub
+	sub := newSpan(name, true)
+	return ContextWithSpan(ctx, sub), sub
 }
 
 // ContextWithSpan returns a new `context.Context` that holds a reference to the provided `span`.
 func ContextWithSpan(ctx context.Context, span Span) context.Context {
 	return context.WithValue(ctx, activeSpanKey, span)
-}
-
-// ContextWithSlowSpan returns a new `context.Context` that holds a reference to the provided `span`
-// as the designated 'slow span'.
-func ContextWithSlowSpan(ctx context.Context, span Span) context.Context {
-	return context.WithValue(ctx, slowSpanKey, span)
 }
 
 // SpanFromContext returns the `Span` previously associated with `ctx`, or a no-op span if none is found.
@@ -38,22 +30,4 @@ func SpanFromContext(ctx context.Context) Span {
 		return sp
 	}
 	return NoopSpan{}
-}
-
-// SpanFromContext returns the `Span` that should be use for tracking slow requests, and if the
-// returned span should be used only for slow requests.
-//
-// If full tracing is enabled, that will be the span returned. Otherwise, it will return the span
-// specifically for slow requests. If neither is found, it will return a no-op span. The no-op span
-// should generally never actually be returned, however.
-func SlowSpanFromContext(ctx context.Context) (Span, bool) {
-	val := ctx.Value(activeSpanKey)
-	if sp, ok := val.(Span); ok && sp.IsRecording() {
-		return sp, false
-	}
-	valSlow := ctx.Value(slowSpanKey)
-	if sp, ok := valSlow.(Span); ok {
-		return sp, true
-	}
-	return NoopSpan{}, false
 }

--- a/util/traceutil/trace/context.go
+++ b/util/traceutil/trace/context.go
@@ -47,7 +47,7 @@ func SpanFromContext(ctx context.Context) Span {
 // should generally never actually be returned, however.
 func SlowSpanFromContext(ctx context.Context) Span {
 	val := ctx.Value(activeSpanKey)
-	if sp, ok := val.(Span); ok {
+	if sp, ok := val.(Span); ok && sp.IsRecording() {
 		return sp
 	}
 	valSlow := ctx.Value(slowSpanKey)

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -309,7 +309,7 @@ func (s *RecordingSpan) SlowSpans() (Span, bool) {
 	}
 	sCopy := s.copy()
 
-	if s.SlowCutoff() != time.Duration(0) && s.Duration() > s.SlowCutoff() {
+	if s.cutoff != time.Duration(0) && s.duration > s.cutoff {
 		return s, true
 	}
 

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -31,7 +31,7 @@ type Span interface {
 	// IsRecording returns true if the span is active and recording events is enabled.
 	IsRecording() bool
 
-	// IsRecording returns true if the span is active and recording events is enabled.
+	// SlowOnly returns true if the span is active and is only for slow request tracing.
 	SlowOnly() bool
 
 	// Json converts the span to its JSON representation.
@@ -171,9 +171,6 @@ func (s *RecordingSpan) End() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	if s.endTime != utc.Zero {
-		return
-	}
 	s.setEnd()
 }
 
@@ -325,8 +322,6 @@ func (s *RecordingSpan) SlowCutoff() time.Duration {
 	return s.Data.Cutoff.Duration()
 }
 
-// SlowSpans returns all spans that have a sub-span that is slower than the cutoff. If there are no
-// slow subspans beneath this span, or this span has not been concluded, it returns false.
 func (s *RecordingSpan) slowSpans() (Span, bool) {
 	notEnded := s.endTime == utc.Zero
 	if notEnded {
@@ -396,6 +391,7 @@ func (s *RecordingSpan) copy() *RecordingSpan {
 		endTime:   s.endTime,
 		duration:  s.duration,
 		extended:  s.extended,
+		slowOnly:  s.slowOnly,
 	}
 	return c
 }

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -84,9 +84,9 @@ type ExtendedSpan interface {
 }
 
 type Event struct {
-	Name     string                 `json:"name"`
-	TimeInto duration.Spec          `json:"time_into"`
-	Attr     map[string]interface{} `json:"attr,omitempty"`
+	Name string                 `json:"name"`
+	At   duration.Spec          `json:"at"`
+	Attr map[string]interface{} `json:"attr,omitempty"`
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -193,9 +193,9 @@ func (s *RecordingSpan) Event(name string, attributes map[string]interface{}) {
 	defer s.mutex.Unlock()
 
 	s.Data.Events = append(s.Data.Events, &Event{
-		Name:     name,
-		TimeInto: duration.Spec(utc.Now().Sub(s.startTime)),
-		Attr:     attributes,
+		Name: name,
+		At:   duration.Spec(utc.Now().Sub(s.startTime)),
+		Attr: attributes,
 	})
 }
 

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -96,9 +96,6 @@ type NoopSpan struct{}
 func (n NoopSpan) Start(ctx context.Context, _ string) (context.Context, Span) {
 	return ctx, n
 }
-func (n NoopSpan) StartSlow(ctx context.Context, _ string) (context.Context, Span) {
-	return ctx, n
-}
 
 func (n NoopSpan) End()                                                 {}
 func (n NoopSpan) Attribute(name string, val interface{})               {}

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -81,9 +81,9 @@ type ExtendedSpan interface {
 }
 
 type Event struct {
-	Name string                 `json:"name"`
-	Time utc.UTC                `json:"-"`
-	Attr map[string]interface{} `json:"attr,omitempty"`
+	Name     string                 `json:"name"`
+	TimeInto duration.Spec          `json:"time_into"`
+	Attr     map[string]interface{} `json:"attr,omitempty"`
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -187,9 +187,9 @@ func (s *RecordingSpan) Event(name string, attributes map[string]interface{}) {
 	defer s.mutex.Unlock()
 
 	s.Data.Events = append(s.Data.Events, &Event{
-		Name: name,
-		Time: utc.Now(),
-		Attr: attributes,
+		Name:     name,
+		TimeInto: duration.Spec(utc.Now().Sub(s.startTime)),
+		Attr:     attributes,
 	})
 }
 

--- a/util/traceutil/trace/span.go
+++ b/util/traceutil/trace/span.go
@@ -334,12 +334,10 @@ func (s *RecordingSpan) MarshalJSON() ([]byte, error) {
 	}
 }
 
-// copy returns a shallow copy of a recording span. In particular, the referenced elements from
-// within the data (Attr, Events, Subs), cannot be modified.
+// copy returns a shallow copy of a recording span. The lock must be held while this function is
+// called. In particular, the referenced elements from within the data (Attr, Events, Subs), cannot
+// be modified.
 func (s *RecordingSpan) copy() *RecordingSpan {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	c := &RecordingSpan{
 		Parent:    s.Parent,
 		Data:      s.Data,

--- a/util/traceutil/traceutil.go
+++ b/util/traceutil/traceutil.go
@@ -50,6 +50,11 @@ func Span() trace.Span {
 	return current().Span()
 }
 
+// SlowSpan retrieves the current slow span of this goroutine, used for tracking slow requests.
+func SlowSpan() trace.Span {
+	return current().SlowSpan()
+}
+
 // Ctx returns the current tracing context. Should only be used for backwards
 // compatibility until old code is converted to use StartSpan directly.
 func Ctx() context.Context {

--- a/util/traceutil/traceutil.go
+++ b/util/traceutil/traceutil.go
@@ -13,14 +13,23 @@ func current() ctxutil.ContextStack {
 }
 
 // InitTracing initializes performance tracing for the current goroutine.
-func InitTracing(spanName string) trace.Span {
-	return current().InitTracing(spanName)
+//
+// If slowOnly is true, only spans that are explicitly created with StartSlowSpan wiill be recorded,
+// and even then only persisted if they end up being slower than expected.
+func InitTracing(spanName string, slowOnly bool) trace.Span {
+	return current().InitTracing(spanName, slowOnly)
 }
 
 // StartSpan creates new sub-span of the goroutine's current span or a noop
 // span if there is no current span.
 func StartSpan(spanName string) trace.Span {
 	return current().StartSpan(spanName)
+}
+
+// StartSlowSpan creates a new sub-span of the goroutine's current slow span or a noop span if there
+// is no current span. If tracing is fully enabled, this has the exact same behavior as StartSpan.
+func StartSlowSpan(spanName string) trace.Span {
+	return current().StartSlowSpan(spanName)
 }
 
 // WithSpan creates a new sub-span of the goroutine's current span and executes

--- a/util/traceutil/traceutil.go
+++ b/util/traceutil/traceutil.go
@@ -23,13 +23,17 @@ func InitTracing(spanName string, slowOnly bool) trace.Span {
 // StartSpan creates new sub-span of the goroutine's current span or a noop
 // span if there is no current span.
 func StartSpan(spanName string) trace.Span {
+	sp := current().Span()
+	if sp.SlowOnly() {
+		return trace.NoopSpan{}
+	}
 	return current().StartSpan(spanName)
 }
 
 // StartSlowSpan creates a new sub-span of the goroutine's current slow span or a noop span if there
 // is no current span. If tracing is fully enabled, this has the exact same behavior as StartSpan.
 func StartSlowSpan(spanName string) trace.Span {
-	return current().StartSlowSpan(spanName)
+	return current().StartSpan(spanName)
 }
 
 // WithSpan creates a new sub-span of the goroutine's current span and executes
@@ -48,11 +52,6 @@ func WithSpan(spanName string, fn func() error) error {
 // Span retrieves the current span of this goroutine.
 func Span() trace.Span {
 	return current().Span()
-}
-
-// SlowSpan retrieves the current slow span of this goroutine, used for tracking slow requests.
-func SlowSpan() trace.Span {
-	return current().SlowSpan()
 }
 
 // Ctx returns the current tracing context. Should only be used for backwards

--- a/util/traceutil/traceutil.go
+++ b/util/traceutil/traceutil.go
@@ -49,7 +49,9 @@ func WithSpan(spanName string, fn func() error) error {
 	return err
 }
 
-// Span retrieves the current span of this goroutine.
+// Span retrieves the current span of this goroutine. If this function is used to add attributes or
+// events to the span, span.SlowOnly should be checked to ensure that detailed tracing is not added
+// when unnecessary.
 func Span() trace.Span {
 	return current().Span()
 }

--- a/util/traceutil/traceutil_test.go
+++ b/util/traceutil/traceutil_test.go
@@ -90,6 +90,7 @@ func TestInitTracing(t *testing.T) {
 
 	slowSp := traceutil.StartSlowSpan("should-appear-slow")
 	require.NotNil(t, slowSp)
+	require.True(t, slowSp.IsRecording())
 	slowSp.Attribute("attr-1", "arbitrary-unique-value")
 
 	slowSp.End()

--- a/util/traceutil/traceutil_test.go
+++ b/util/traceutil/traceutil_test.go
@@ -169,3 +169,11 @@ func TestExtendedSpan(t *testing.T) {
 func removeMs(s string) string {
 	return regexp.MustCompile(`\.00\dZ`).ReplaceAllString(s, "")
 }
+
+func TestNilAppend(t *testing.T) {
+	rg := map[string][]int{}
+	rg["a"] = append(rg["a"], 1)
+	println(len(rg["a"]))
+	println(rg["a"][0])
+	t.Fail()
+}

--- a/util/traceutil/traceutil_test.go
+++ b/util/traceutil/traceutil_test.go
@@ -87,6 +87,7 @@ func TestInitTracing(t *testing.T) {
 
 	span := traceutil.StartSpan("should-appear-regular")
 	require.NotNil(t, span)
+	require.True(t, span.IsRecording())
 
 	slowSp := traceutil.StartSlowSpan("should-appear-slow")
 	require.NotNil(t, slowSp)

--- a/util/traceutil/traceutil_test.go
+++ b/util/traceutil/traceutil_test.go
@@ -169,11 +169,3 @@ func TestExtendedSpan(t *testing.T) {
 func removeMs(s string) string {
 	return regexp.MustCompile(`\.00\dZ`).ReplaceAllString(s, "")
 }
-
-func TestNilAppend(t *testing.T) {
-	rg := map[string][]int{}
-	rg["a"] = append(rg["a"], 1)
-	println(len(rg["a"]))
-	println(rg["a"][0])
-	t.Fail()
-}

--- a/util/traceutil/traceutil_test.go
+++ b/util/traceutil/traceutil_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/eluv-io/utc-go"
 
-	"github.com/eluv-io/common-go/util/ctxutil"
 	"github.com/eluv-io/common-go/util/traceutil"
 	"github.com/eluv-io/common-go/util/traceutil/trace"
 )
@@ -68,8 +67,8 @@ func TestSlowSpanInit(t *testing.T) {
 
 func TestInitTracing(t *testing.T) {
 	rootSp := traceutil.InitTracing("init-tracing-test", false)
-	require.Equal(t, ctxutil.Current().Span(), ctxutil.Current().SlowSpan())
 	require.True(t, rootSp.IsRecording())
+	require.False(t, rootSp.SlowOnly())
 
 	span := traceutil.StartSpan("should-appear-regular")
 	require.NotNil(t, span)


### PR DESCRIPTION
Expand tracing spans such that:

- events report the duration into a span that they occurred
- spans can say that they are 'slow only', indicating they should only be used for tracing slow requests.
- `traceutil` respects that, and calls to `StartSpan` are ignored when only slow spans are checked.
- They can optionally have a deadline, and are considered 'slow' if the deadline is exceeded.
- Marshal only spans that have a parent, child, or are themselves slow.

Intended usage looks something like:

```go

slowOnly := true // could be false
rootSp := traceutil.InitTracing("root", slowOnly)
defer rootSp.End()

fullTrSp := traceutil.StartSpan("operation-that-should-only-be-traced-with-full-tracing")
// Do the operation
fullTrSp.End()

slowTrSp := traceutil.StartSlowSpan("operation-that-may-be-slow")
slowTrSp.SetSlowCutoff(time.Second)
// Do the operation
slowTrSp.End()

// Add attribute to active span always
traceutil.Span().Attribute("always", true)

// Add attribute only when tracing slow requests
if !traceutil.Span().SlowOnly() {
  traceutil.Span().Attribute("only-when-full", true)
}

```