### PR TITLE
add storage ID support to `format/hash`

### DIFF
--- a/format/factory.go
+++ b/format/factory.go
@@ -16,8 +16,6 @@ import (
 // Factory provides all format-related constructors and generators like codecs,
 // digests, etc.
 type Factory interface {
-	// NewContentDigest returns a digest object for calculating content hashes.
-	NewContentDigest(format hash.Format, id QID) *hash.Digest
 	// NewContentPartDigest returns a digest object for calculating content hashes.
 	NewContentPartDigest(format hash.Format) *hash.Digest
 
@@ -98,11 +96,6 @@ func NewFactory() Factory {
 // Factory is the factory for all format-related generators like codecs,
 // digests, etc.
 type factory struct{}
-
-// NewContentDigest returns a digest object for calculating content hashes.
-func (f *factory) NewContentDigest(format hash.Format, id QID) *hash.Digest {
-	return hash.NewDigest(sha256.New(), hash.Type{hash.Q, format}).WithID(id)
-}
 
 // NewContentPartDigest returns a digest object for calculating content hashes.
 func (f *factory) NewContentPartDigest(format hash.Format) *hash.Digest {

--- a/format/factory_test.go
+++ b/format/factory_test.go
@@ -19,10 +19,12 @@ import (
 func TestContentDigest(t *testing.T) {
 	f := NewTestFactory(t)
 
-	d := f.NewContentDigest(hash.Unencrypted, f.GenerateQID())
+	d := f.NewContentPartDigest(hash.Unencrypted)
 	h := fill(t, d)
-	assert.NoError(t, h.AssertCode(hash.Q))
+	assert.NoError(t, h.AssertCode(hash.QPart))
 
+	h, err := h.AsContentHash(f.GenerateQID())
+	assert.NoError(t, err)
 	assert.Contains(t, h.String(), "hq__")
 }
 
@@ -84,7 +86,6 @@ func TestHashGenerators(t *testing.T) {
 		md     *hash.Digest
 		prefix string
 	}{
-		{"ContentDigest", f.NewContentDigest(hash.Unencrypted, f.GenerateQID()), "hq__"},
 		{"ContentPartDigest", f.NewContentPartDigest(hash.Unencrypted), "hqp_"},
 	}
 	for _, v := range tests {

--- a/format/hash/digest.go
+++ b/format/hash/digest.go
@@ -1,0 +1,137 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"hash"
+	"io"
+
+	ei "github.com/eluv-io/common-go/format/id"
+	"github.com/eluv-io/common-go/format/preamble"
+	"github.com/eluv-io/errors-go"
+	"github.com/eluv-io/log-go"
+)
+
+// Digest encapsulates a message digest function which produces a specific type of Hash
+type Digest struct {
+	hash.Hash
+	preamble  *preamble.Sizer
+	htype     Type
+	id        ei.ID
+	size      int64
+	psize     int64
+	storageId uint
+}
+
+// make sure Digest implements the Hash interface
+var _ hash.Hash = (*Digest)(nil)
+
+// NewDigest creates a new digest. Does not support live part hashes
+func NewDigest(h hash.Hash, t Type) *Digest {
+	return &Digest{Hash: h, preamble: preamble.NewSizer(), htype: t}
+}
+
+func (d *Digest) WithPreamble(preambleSize int64) *Digest {
+	if d.htype.Code == QPart {
+		if preambleSize > 0 {
+			d.psize = preambleSize
+		} else {
+			// Calculate preamble size
+			var err error
+			d.psize, err = d.preamble.Size()
+			if err != nil {
+				// Should not happen
+				log.Warn("invalid hash", "error", err)
+			}
+		}
+	} else {
+		// Should not happen
+		log.Warn("invalid hash", "error", "preamble not applicable", "code", d.htype.Code)
+	}
+	return d
+}
+
+func (d *Digest) WithID(i ei.ID) *Digest {
+	if d.htype.Code == Q {
+		d.id = i
+	}
+	return d
+}
+
+func (d *Digest) WithStorageId(sc uint) *Digest {
+	d.storageId = sc
+	return d
+}
+
+func (d *Digest) Write(p []byte) (int, error) {
+	n, err := d.Hash.Write(p)
+	if err == nil && d.htype.Code == QPart {
+		n2, err2 := d.preamble.Write(p)
+		if err2 != nil || n2 != n {
+			// Should not happen
+			log.Warn("invalid hash", "error", err, "n", n, "n2", n2)
+		}
+	}
+	d.size += int64(n)
+	return n, err
+}
+
+// AsHash finalizes the digest calculation using all the bytes that were previously written to this digest object and
+// return the result as a Hash.
+func (d *Digest) AsHash() *Hash {
+	b := d.Hash.Sum(nil)
+	var h *Hash
+	var err error
+	if d.htype.Code == Q {
+		h, err = NewObject(d.htype, b, d.size, d.id)
+	} else {
+		h, err = NewPart(d.htype, b, d.size, d.psize)
+	}
+	if err != nil {
+		// errors must be caught by unit tests!
+		log.Fatal("invalid hash", "error", err)
+	}
+	return h
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+func CalcHash(reader io.ReadSeeker, size ...int64) (*Hash, error) {
+	digest := NewDigest(sha256.New(), Type{QPart, Unencrypted})
+
+	// Check for preamble
+	var preambleSize int64
+	var err error
+	if len(size) > 0 {
+		_, _, preambleSize, err = preamble.Read(reader, false, size[0])
+	} else {
+		_, _, preambleSize, err = preamble.Read(reader, false)
+	}
+	if errors.IsNotExist(err) {
+		preambleSize = 0
+	} else if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 128*1024)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			_, err = digest.Write(buf[:n])
+			if err != nil {
+				return nil, err
+			}
+		}
+		if err == io.EOF {
+			err = nil
+			break
+		} else if err != nil {
+			return nil, err
+		}
+	}
+
+	if preambleSize > 0 {
+		digest = digest.WithPreamble(preambleSize)
+	}
+
+	return digest.AsHash(), nil
+}

--- a/format/hash/digest_test.go
+++ b/format/hash/digest_test.go
@@ -1,0 +1,59 @@
+package hash_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/eluv-io/common-go/format/hash"
+	"github.com/eluv-io/common-go/format/id"
+)
+
+func TestDigest(t *testing.T) {
+	idx, _ := id.FromString("iq__WxoChT9EZU2PRdTdNU7Ldf")
+
+	d := hash.NewBuilder()
+	b := make([]byte, 1024)
+
+	n, err := rand.Read(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, n)
+
+	n, err = d.Write(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, n)
+
+	h, err := d.BuildHash()
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+	assert.Equal(t, hash.QPart, h.Type.Code)
+	assert.Equal(t, hash.Unencrypted, h.Type.Format)
+
+	h, err = h.AsContentHash(idx)
+	assert.NoError(t, err)
+	assert.NoError(t, h.AssertCode(hash.Q))
+
+	assert.NotNil(t, h)
+	assert.NoError(t, h.AssertCode(hash.Q))
+
+	fmt.Println(h)
+}
+
+func TestEmptyDigest(t *testing.T) {
+	idx, _ := id.FromString("iq__WxoChT9EZU2PRdTdNU7Ldf")
+
+	h, err := hash.NewBuilder().BuildHash()
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+
+	fmt.Println(h)
+
+	h, err = h.AsContentHash(idx)
+	assert.NoError(t, err)
+	assert.NoError(t, h.AssertCode(hash.Q))
+
+	fmt.Println(h)
+	fmt.Println(h.Describe())
+}

--- a/format/hash/hash.go
+++ b/format/hash/hash.go
@@ -5,8 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"hash"
-	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -15,7 +13,6 @@ import (
 	"github.com/mr-tron/base58/base58"
 
 	ei "github.com/eluv-io/common-go/format/id"
-	"github.com/eluv-io/common-go/format/preamble"
 	"github.com/eluv-io/common-go/util/byteutil"
 	"github.com/eluv-io/errors-go"
 	"github.com/eluv-io/log-go"
@@ -669,131 +666,4 @@ func (h *Hash) Describe() string {
 	}
 
 	return sb.String()
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// Digest encapsulates a message digest function which produces a specific type of Hash
-type Digest struct {
-	hash.Hash
-	preamble  *preamble.Sizer
-	htype     Type
-	id        ei.ID
-	size      int64
-	psize     int64
-	storageId uint
-}
-
-// make sure Digest implements the Hash interface
-var _ hash.Hash = (*Digest)(nil)
-
-// NewDigest creates a new digest. Does not support live part hashes
-func NewDigest(h hash.Hash, t Type) *Digest {
-	return &Digest{Hash: h, preamble: preamble.NewSizer(), htype: t}
-}
-
-func (d *Digest) WithPreamble(preambleSize int64) *Digest {
-	if d.htype.Code == QPart {
-		if preambleSize > 0 {
-			d.psize = preambleSize
-		} else {
-			// Calculate preamble size
-			var err error
-			d.psize, err = d.preamble.Size()
-			if err != nil {
-				// Should not happen
-				log.Warn("invalid hash", "error", err)
-			}
-		}
-	} else {
-		// Should not happen
-		log.Warn("invalid hash", "error", "preamble not applicable", "code", d.htype.Code)
-	}
-	return d
-}
-
-func (d *Digest) WithID(i ei.ID) *Digest {
-	if d.htype.Code == Q {
-		d.id = i
-	}
-	return d
-}
-
-func (d *Digest) WithStorageId(sc uint) *Digest {
-	d.storageId = sc
-	return d
-}
-
-func (d *Digest) Write(p []byte) (int, error) {
-	n, err := d.Hash.Write(p)
-	if err == nil && d.htype.Code == QPart {
-		n2, err2 := d.preamble.Write(p)
-		if err2 != nil || n2 != n {
-			// Should not happen
-			log.Warn("invalid hash", "error", err, "n", n, "n2", n2)
-		}
-	}
-	d.size += int64(n)
-	return n, err
-}
-
-// AsHash finalizes the digest calculation using all the bytes that were previously written to this digest object and
-// return the result as a Hash.
-func (d *Digest) AsHash() *Hash {
-	b := d.Hash.Sum(nil)
-	var h *Hash
-	var err error
-	if d.htype.Code == Q {
-		h, err = NewObject(d.htype, b, d.size, d.id)
-	} else {
-		h, err = NewPart(d.htype, b, d.size, d.psize)
-	}
-	if err != nil {
-		// errors must be caught by unit tests!
-		log.Fatal("invalid hash", "error", err)
-	}
-	return h
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-func CalcHash(reader io.ReadSeeker, size ...int64) (*Hash, error) {
-	digest := NewDigest(sha256.New(), Type{QPart, Unencrypted})
-
-	// Check for preamble
-	var preambleSize int64
-	var err error
-	if len(size) > 0 {
-		_, _, preambleSize, err = preamble.Read(reader, false, size[0])
-	} else {
-		_, _, preambleSize, err = preamble.Read(reader, false)
-	}
-	if errors.IsNotExist(err) {
-		preambleSize = 0
-	} else if err != nil {
-		return nil, err
-	}
-
-	buf := make([]byte, 128*1024)
-	for {
-		n, err := reader.Read(buf)
-		if n > 0 {
-			_, err = digest.Write(buf[:n])
-			if err != nil {
-				return nil, err
-			}
-		}
-		if err == io.EOF {
-			err = nil
-			break
-		} else if err != nil {
-			return nil, err
-		}
-	}
-
-	if preambleSize > 0 {
-		digest = digest.WithPreamble(preambleSize)
-	}
-
-	return digest.AsHash(), nil
 }

--- a/format/hash/hash.go
+++ b/format/hash/hash.go
@@ -29,20 +29,37 @@ const (
 	QPart                   // regular part hash
 	QPartLive               // live part that generates a regular part upon finalization for vod
 	QPartLiveTransient      // live part that doesn't generate a regular part upon finalization
-	CPart                   // content part hash including storage ID
-	CPartLive               // live content part hash including storage ID
+	C                       // content object hash     --> including storage ID
+	CPart                   // content part hash       --> including storage ID
+	CPartLive               // live content part hash  --> including storage ID
 
 	// live content part hash including storage ID that doesn't generate a regular part upon finalization
 	// PENDING(LUK): is this really needed?
 	CPartLiveTransient
 )
 
+func (c Code) IsContent() bool {
+	return c == Q || c == C
+}
+
+func (c Code) IsPart() bool {
+	return c == QPart ||
+		c == CPart ||
+		c == QPartLive ||
+		c == QPartLiveTransient ||
+		c == CPartLive ||
+		c == CPartLiveTransient
+}
+
 func (c Code) IsLive() bool {
-	return c == QPartLive || c == QPartLiveTransient || c == CPartLive || c == CPartLiveTransient
+	return c == QPartLive ||
+		c == QPartLiveTransient ||
+		c == CPartLive ||
+		c == CPartLiveTransient
 }
 
 func (c Code) hasStorageId() bool {
-	return c == CPart || c == CPartLive || c == CPartLiveTransient
+	return c == C || c == CPart || c == CPartLive || c == CPartLiveTransient
 }
 
 // FromString parses the given string and returns the hash.
@@ -67,7 +84,7 @@ func (c Code) MustParse(s string) *Hash {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Format is the format of a hash
+// Format is the format of a hash: Unencrypted|AES128AFGH
 type Format uint8
 
 const (
@@ -87,7 +104,7 @@ func (f Format) FromString(s string) (*Hash, error) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// Type, the composition of Code and Format, is the type of a hash
+// Type is the composition of Code and Format.
 type Type struct {
 	Code   Code
 	Format Format
@@ -118,10 +135,12 @@ func (t Type) Describe() string {
 		c = "live content part"
 	case QPartLiveTransient:
 		c = "transient live content part"
+	case C:
+		c = "content with storage id"
 	case CPart:
-		c = "content part with storage ID"
+		c = "content part with storage id"
 	case CPartLive:
-		c = "live content part with storage ID"
+		c = "live content part with storage id"
 	case CPartLiveTransient:
 		c = "transient live content part"
 	}
@@ -132,6 +151,15 @@ func (t Type) Describe() string {
 		f = "encrypted with AES-128, AFGHG BLS12-381, 1 MB block size"
 	}
 	return c + ", " + f
+}
+
+func (t Type) IsValid() bool {
+	if _, ok := typeToPrefix[t]; !ok {
+		return false
+	} else if t.Code == UNKNOWN {
+		return false
+	}
+	return true
 }
 
 const prefixLen = 4
@@ -146,6 +174,7 @@ var prefixToType = map[string]Type{
 	"hqle": {QPartLive, AES128AFGH},
 	"hqt_": {QPartLiveTransient, Unencrypted},
 	"hqte": {QPartLiveTransient, AES128AFGH},
+	"hc__": {C, Unencrypted},
 	"hcp_": {CPart, Unencrypted},
 	"hcpe": {CPart, AES128AFGH},
 	"hcl_": {CPartLive, Unencrypted},
@@ -175,9 +204,30 @@ func init() {
 //	QPartLive:          type (1 byte) | expiration (var bytes) | digest (var bytes)
 //	QPartLiveTransient: type (1 byte) | expiration (var bytes) | digest (var bytes)
 //	(Old) QPartLive:    type (1 byte) | digest (24-25 bytes)
-//	CPart:              type (1 byte) | storage ID (var bytes) | digest (var bytes) | size (var bytes) | id (var bytes)
+//	C:                  type (1 byte) | storage ID (var bytes) | digest (var bytes) | size (var bytes) | id (var bytes)
+//	QPart:              type (1 byte) | storage ID (var bytes) | digest (var bytes) | size (var bytes) | preamble_size (var bytes, optional)
 //	CPartLive:          type (1 byte) | storage ID (var bytes) | expiration (var bytes) | digest (var bytes)
 //	CPartLiveTransient: type (1 byte) | storage ID (var bytes) | expiration (var bytes) | digest (var bytes)
+//
+// The preferred way to create regular part and content hashes is using the builder:
+//
+//	digest := hash.NewBuilder().WithStorageId(storageId).WithXyz(...)
+//	digest.Write(data)
+//	...
+//	partHash, err := digest.BuildHash()
+//
+// This creates a regular content part hash. If this is the hash of the content object's qstruct part (or qref part for
+// V1 objects), then the hash can be converted to a content hash using:
+//
+//	contentHash, err := partHash.AsContentHash(contentID)
+//
+// To derive the part hash from a content hash, use:
+//
+//	partHash, err := contentHash.AsPartHash()
+//
+// Live hashes are created using the NewLive function:
+//
+//	hash, err := NewLive(Type{QPartLive, Unencrypted}, digest, expiration)
 type Hash struct {
 	Type         Type
 	Digest       []byte
@@ -190,37 +240,30 @@ type Hash struct {
 }
 
 // NewObject creates a new object hash with the given type, digest, size, and ID
+//
+// Deprecated: use NewBuilder().BuildHash(), then AsContentHash() instead.
 func NewObject(htype Type, digest []byte, size int64, id ei.ID) (*Hash, error) {
 	e := errors.TemplateNoTrace("init hash", errors.K.Invalid)
-	if _, ok := typeToPrefix[htype]; !ok {
-		return nil, e("reason", "invalid type", "code", htype.Code, "format", htype.Format)
-	} else if htype.Code == UNKNOWN {
-		return nil, nil
-	} else if htype.Code != Q {
+	if !htype.Code.IsContent() {
 		return nil, e("reason", "code not supported", "code", htype.Code)
 	}
 
-	if len(digest) != sha256.Size {
-		return nil, e("reason", "invalid digest", "digest", digest)
-	}
-
-	if size < 0 {
-		return nil, e("reason", "invalid size", "size", size)
-	}
-
-	if id.AssertCode(ei.Q) != nil {
-		return nil, e("reason", "invalid id", "id", id)
-	}
-
 	h := &Hash{Type: htype, Digest: digest, Size: size, ID: id}
-	h.s = h.String()
+	if err := h.Validate(); err != nil {
+		return nil, e(err)
+	}
 
+	h.s = h.String()
 	return h, nil
 }
 
 // NewPart creates a new non-live part hash with the given type, digest, size, and optional preamble size
+//
+// Deprecated: use NewBuilder().BuildHash() instead.
 func NewPart(htype Type, digest []byte, size int64, preambleSize int64) (*Hash, error) {
-	e := errors.TemplateNoTrace("init hash", errors.K.Invalid)
+	e := errors.TemplateNoTrace("NewPartHash", errors.K.Invalid)
+
+	// this code is left unchanged for backwards compatibility
 	if _, ok := typeToPrefix[htype]; !ok {
 		return nil, e("reason", "invalid type", "code", htype.Code, "format", htype.Format)
 	} else if htype.Code == UNKNOWN {
@@ -229,21 +272,39 @@ func NewPart(htype Type, digest []byte, size int64, preambleSize int64) (*Hash, 
 		return nil, e("reason", "code not supported", "code", htype.Code)
 	}
 
+	if size < 0 {
+		return nil, e("reason", "invalid part size", "size", size)
+	}
+	if preambleSize < 0 {
+		return nil, e("reason", "invalid preamble size", "preamble_size", preambleSize)
+	}
+
+	return newPart(htype.Format, digest, uint64(size), uint64(preambleSize), 0)
+}
+
+// newPart creates a new non-live part hash with the given type, digest, size, preamble size and storage ID
+func newPart(format Format, digest []byte, size uint64, preambleSize uint64, storageId uint) (*Hash, error) {
+	e := errors.TemplateNoTrace("NewPartHash", errors.K.Invalid)
+
 	if len(digest) != sha256.Size {
 		return nil, e("reason", "invalid digest", "digest", digest)
 	}
 
-	if size < 0 {
-		return nil, e("reason", "invalid size", "size", size)
+	code := QPart
+	if storageId > 0 {
+		code = CPart
 	}
 
-	if preambleSize < 0 {
-		return nil, e("reason", "invalid preamble size", "preamble_size", size)
+	h := &Hash{Type: Type{
+		Code:   code,
+		Format: format,
+	}, Digest: digest, Size: int64(size), PreambleSize: int64(preambleSize), StorageId: storageId}
+
+	if err := h.Validate(); err != nil {
+		return nil, e(err)
 	}
 
-	h := &Hash{Type: htype, Digest: digest, Size: size, PreambleSize: preambleSize}
 	h.s = h.String()
-
 	return h, nil
 }
 
@@ -264,8 +325,11 @@ func NewLive(htype Type, digest []byte, expiration utc.UTC) (*Hash, error) {
 	expiration = expiration.Truncate(time.Second)
 
 	h := &Hash{Type: htype, Digest: digest, Expiration: expiration}
-	h.s = h.String()
+	if err := h.Validate(); err != nil {
+		return nil, e(err)
+	}
 
+	h.s = h.String()
 	return h, nil
 }
 
@@ -399,7 +463,7 @@ func (h *Hash) String() string {
 		return ""
 	}
 
-	if h.s == "" && len(h.Digest) > 0 {
+	if h.s == "" {
 		h.s = h.prefix() + base58.Encode(h.DecodedBytes())
 	}
 
@@ -408,20 +472,16 @@ func (h *Hash) String() string {
 
 // DecodedBytes converts this hash to base58-decoded bytes.
 func (h *Hash) DecodedBytes() []byte {
-	if len(h.Digest) == 0 {
-		return nil
-	}
-
 	var b []byte
 	if !h.IsLive() {
 		bufLen := len(h.Digest) + byteutil.LenUvarInt(uint64(h.Size))
 		if h.hasStorageId() {
 			bufLen += byteutil.LenUvarInt(uint64(h.StorageId))
 		}
-		if h.Type.Code == QPart && h.PreambleSize > 0 {
-			bufLen += byteutil.LenUvarInt(uint64(h.PreambleSize))
-		} else if h.Type.Code == Q && h.ID.IsValid() {
+		if h.Type.Code.IsContent() {
 			bufLen += len(h.ID.Bytes())
+		} else if h.Type.Code.IsPart() && h.PreambleSize > 0 {
+			bufLen += byteutil.LenUvarInt(uint64(h.PreambleSize))
 		}
 
 		b = make([]byte, bufLen)
@@ -434,10 +494,10 @@ func (h *Hash) DecodedBytes() []byte {
 		n += copy(b[n:], h.Digest)
 		n += binary.PutUvarint(b[n:], uint64(h.Size))
 
-		if h.Type.Code == QPart && h.PreambleSize > 0 {
-			n += binary.PutUvarint(b[n:], uint64(h.PreambleSize))
-		} else if h.Type.Code == Q && h.ID.IsValid() {
+		if h.Type.Code.IsContent() {
 			n += copy(b[n:], h.ID.Bytes())
+		} else if h.Type.Code.IsPart() && h.PreambleSize > 0 {
+			n += binary.PutUvarint(b[n:], uint64(h.PreambleSize))
 		}
 	} else {
 		expirationUnix := h.Expiration.Unix()
@@ -566,27 +626,112 @@ func (h *Hash) UnmarshalText(text []byte) error {
 }
 
 // As returns a copy of this hash with the given code as the type of the new hash.
+//
+// Deprecated: use AsContentHash() or AsPartHash() instead.
 func (h *Hash) As(c Code, id ei.ID) (*Hash, error) {
+	e := errors.TemplateNoTrace("convert hash", errors.K.Invalid)
 	if h.IsNil() || c == h.Type.Code {
 		return h, nil
 	} else if h.PreambleSize > 0 {
-		return nil, errors.NoTrace("convert hash", errors.K.Invalid, "reason", "no conversion for parts with preamble", "hash", h)
-	} else if h.IsLive() || c.IsLive() {
-		return nil, errors.NoTrace("convert hash", errors.K.Invalid, "reason", "no conversion for live parts", "hash", h, "code", c)
+		return nil, e("reason", "no conversion for parts with preamble", "hash", h)
+	} else if h.IsLive() {
+		return nil, e("reason", "no conversion for live parts", "hash", h, "code", c)
 	} else if _, ok := typeToPrefix[Type{c, h.Type.Format}]; !ok {
-		return nil, errors.NoTrace("convert hash", errors.K.Invalid, "reason", "invalid type", "code", c, "format", h.Type.Format)
+		return nil, e("reason", "invalid type", "code", c, "format", h.Type.Format)
 	}
 	var res = *h // copy
 	res.Type.Code = c
 	res.s = ""
-	if c != Q {
+	if c != Q && c != C {
 		res.ID = nil
 	} else if id != nil && id.AssertCode(ei.Q) == nil {
 		res.ID = id
 	} else {
-		return nil, errors.NoTrace("convert hash", errors.K.Invalid, "reason", "invalid id", "id", id)
+		return nil, e("reason", "invalid id", "id", id)
 	}
 	res.s = res.String()
+	return &res, nil
+}
+
+// AsContentHash returns a copy of this (part) hash as a content hash with the given ID. Returns an error if the ID is
+// not a valid content ID or if the hash cannot be converted to a content hash.
+func (h *Hash) AsContentHash(id ei.ID) (*Hash, error) {
+	e := errors.TemplateNoTrace("hash.AsContentHash", errors.K.Invalid, "hash", h, "id", id)
+	if err := id.AssertCode(ei.Q); err != nil {
+		return nil, e("reason", "invalid content id")
+	}
+	if h.IsNil() {
+		return h, e("reason", "hash is nil")
+	}
+	if h.Type.Code.IsContent() {
+		// replace content id
+		var res = *h // copy
+		res.ID = id
+		res.s = ""
+		res.s = res.String()
+		if err := res.Validate(); err != nil {
+			return nil, e(err)
+		}
+		return &res, nil
+	}
+	if h.PreambleSize > 0 {
+		return nil, e("reason", "no conversion for parts with preamble")
+	}
+	if h.IsLive() {
+		return nil, e("reason", "no conversion for live parts")
+	}
+
+	targetCode := Q
+	if h.hasStorageId() {
+		targetCode = C
+	}
+
+	if _, ok := typeToPrefix[Type{targetCode, h.Type.Format}]; !ok {
+		return nil, e("reason", "invalid type", "code", targetCode, "format", h.Type.Format)
+	}
+
+	var res = *h // copy
+	res.Type.Code = targetCode
+	res.ID = id
+	res.s = ""
+	res.s = res.String()
+	if err := res.Validate(); err != nil {
+		return nil, e(err)
+	}
+	return &res, nil
+}
+
+// AsPartHash returns a copy of this (content) hash as a part hash, or an error if the hash cannot be converted to a
+// part hash.
+func (h *Hash) AsPartHash() (*Hash, error) {
+	e := errors.TemplateNoTrace("hash.AsPartHash", errors.K.Invalid, "hash", h)
+	if h.IsNil() {
+		return nil, e("reason", "hash is nil")
+	}
+	if h.Type.Code.IsPart() {
+		return nil, e("reason", "hash is already a part hash")
+	}
+	if h.Type.Format != Unencrypted {
+		return nil, e("reason", "no conversion for encrypted hash")
+	}
+
+	targetCode := QPart
+	if h.hasStorageId() {
+		targetCode = CPart
+	}
+
+	if _, ok := typeToPrefix[Type{targetCode, h.Type.Format}]; !ok {
+		return nil, e("reason", "invalid type", "code", targetCode, "format", h.Type.Format)
+	}
+
+	var res = *h // copy
+	res.Type.Code = targetCode
+	res.ID = nil
+	res.s = ""
+	res.s = res.String()
+	if err := res.Validate(); err != nil {
+		return nil, e(err)
+	}
 	return &res, nil
 }
 
@@ -622,6 +767,8 @@ func (h *Hash) AssertEqual(h2 *Hash) error {
 		return e("reason", "id differs", "expected_id", h.ID, "actual_id", h2.ID)
 	case h.Expiration != h2.Expiration:
 		return e("reason", "expiration differs", "expected_expiration", h.Expiration, "actual_expiration", h2.Expiration)
+	case h.StorageId != h2.StorageId:
+		return e("reason", "storage id differs", "expected_storage_id", h.StorageId, "actual_storage_id", h2.StorageId)
 	default:
 		return nil
 	}
@@ -643,11 +790,11 @@ func (h *Hash) Describe() string {
 	}
 
 	add("type:          " + h.Type.Describe())
-	sc := "default"
+	sc := "0 (default)"
 	if h.hasStorageId() {
 		sc = strconv.FormatUint(uint64(h.StorageId), 10)
 	}
-	add("storage ID: " + sc)
+	add("storage id:    " + sc)
 	add("digest:        0x" + hex.EncodeToString(h.Digest))
 	if !h.IsLive() {
 		add("size:          " + strconv.FormatInt(h.Size, 10))
@@ -657,13 +804,71 @@ func (h *Hash) Describe() string {
 	} else {
 		add("expiration:    " + h.Expiration.String())
 	}
-	if h.Type.Code == Q {
+	if h.Type.Code == Q || h.Type.Code == C {
 		add("qid:           " + h.ID.String())
-		qphash, err := h.As(QPart, nil)
+		qphash, err := h.AsPartHash()
 		if err == nil {
 			add("part:          " + qphash.String())
+		} else {
+			add("part:          Failed to convert to part hash: " + err.Error())
 		}
 	}
 
 	return sb.String()
+}
+
+func (h *Hash) IsValid() bool {
+	return h.Validate() == nil
+}
+
+func (h *Hash) Validate() error {
+	e := errors.TemplateNoTrace("hash.Validate", errors.K.Invalid.Default(), "hash", h)
+	if h == nil {
+		return e("reason", "hash is nil")
+	}
+	if !h.Type.IsValid() {
+		return e("reason", "invalid type", "code", h.Type.Code, "format", h.Type.Format)
+	}
+	if len(h.Digest) != sha256.Size {
+		if len(h.Digest) == 0 {
+			return e("reason", "empty digest")
+		} else if !h.IsLive() {
+			return e("reason", "invalid digest", "size", len(h.Digest))
+		}
+	}
+	if h.Size < 0 {
+		return e("reason", "invalid part size", "size", h.Size)
+	}
+	if h.PreambleSize < 0 {
+		return e("reason", "invalid preamble size", "preamble_size", h.Size)
+	}
+	if !h.Type.Code.hasStorageId() && h.StorageId != 0 {
+		return e("reason", "storage id not allowed", "storage_id", h.StorageId)
+	}
+
+	if h.Type.Code.IsContent() {
+		if err := h.ID.AssertCode(ei.Q); err != nil {
+			return e("reason", "invalid id", "id", h.ID)
+		}
+		if !h.Expiration.IsZero() {
+			return e("reason", "expiration not allowed for content hash", "expiration", h.Expiration)
+		}
+		if h.PreambleSize != 0 {
+			return e("reason", "preamble size not allowed for content hash", "preamble_size", h.Size)
+		}
+	} else if h.Type.Code.IsPart() {
+		if h.ID.IsValid() {
+			return e("reason", "id not allowed for part hash", "id", h.ID)
+		}
+		if h.Type.Code.IsLive() {
+			if h.PreambleSize != 0 {
+				return e("reason", "preamble size not allowed for live part hash", "preamble_size", h.Size)
+			}
+		} else {
+			if !h.Expiration.IsZero() {
+				return e("reason", "expiration not allowed for non-live hash", "expiration", h.Expiration)
+			}
+		}
+	}
+	return nil
 }

--- a/format/link/builder_test.go
+++ b/format/link/builder_test.go
@@ -81,9 +81,10 @@ func init() {
 }
 
 func randomQHash() types.QHash {
-	digest := ff.NewContentDigest(hash.Unencrypted, ff.GenerateQID())
+	digest := ff.NewContentPartDigest(hash.Unencrypted)
 	_, _ = digest.Write(byteutil.RandomBytes(10))
-	return digest.AsHash()
+	h, _ := digest.AsHash().AsContentHash(ff.GenerateQID())
+	return h
 }
 
 func randomQPHash() types.QPHash {

--- a/format/module_test.go
+++ b/format/module_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/eluv-io/common-go/format/hash"
 
-	"github.com/eluv-io/inject-go"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/eluv-io/inject-go"
 )
 
 func TestModule(t *testing.T) {
 	f := NewTestFactory(t)
-
-	f.NewContentDigest(hash.Unencrypted, f.GenerateQID())
+	f.NewContentPartDigest(hash.Unencrypted)
 }
 
 func NewTestFactory(t *testing.T) Factory {


### PR DESCRIPTION
Adds new hash types that include a storage ID (C, CPart, CPartLive, CPartLiveTransient). 

I deprecated a couple constructor functions because they are potentially unsafe and lead wrong utilization. Instead, I added a hash builder (implemented by the Digest, because that’s what it essentially is) and explicit conversion functions to convert hashes from part to content hashes and vice-versa. I did not remove any of the old functions because they are used all over the place in unit tests. An exception to this is Factory.NewContentDigest(), which makes really no sense, so I removed it.

This changeset requires few changes in content-fabric, branch `luk/hash-storage-id`.