### PR TITLE
Add Must and IgnoreErr to facilitate inline code

### DIFF
--- a/util/ifutil/ifutil.go
+++ b/util/ifutil/ifutil.go
@@ -130,3 +130,18 @@ func Diff(labelA string, a interface{}, labelB string, b interface{}) string {
 	}
 	return diff[:len(diff)-2]
 }
+
+// Must takes an object and an error, and panics if the error is not nil. It can be used for
+// inlining function calls when you know that the function won't error.
+func Must[T any](value T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return value
+}
+
+// IgnoreErr takes an object and an error, and ignores the error. It can be used for inlining
+// function calls.
+func IgnoreErr[T any](value T, _ error) T {
+	return value
+}

--- a/util/ifutil/ifutil.go
+++ b/util/ifutil/ifutil.go
@@ -134,7 +134,7 @@ func Diff(labelA string, a interface{}, labelB string, b interface{}) string {
 // Must takes an object and an error, and panics if the error is not nil. It can be used for
 // inlining function calls when you know that the function won't error.
 func Must[T any](value T, err error) T {
-	if err != nil {
+	if !IsNil(err) {
 		panic(err)
 	}
 	return value

--- a/util/ifutil/ifutil_test.go
+++ b/util/ifutil/ifutil_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type chanType = chan bool
@@ -246,6 +247,23 @@ func TestFirstNonZero(t *testing.T) {
 	assert.Equal(t, 1.0, FirstNonZero(0.0, 1.0, 2.0))
 	assert.Equal(t, "", FirstNonZero[string]())
 	assert.Equal(t, "a", FirstNonZero("", "a", "b"))
+}
+
+// verr implements error
+type verr struct{}
+
+func (e *verr) Error() string { return "" }
+
+func TestMust(t *testing.T) {
+	validate := func() *verr {
+		return nil
+	}
+
+	// Basic tests
+	require.Panics(t, func() { Must(1, fmt.Errorf("encountered error")) })
+	require.Equal(t, 1, Must(1, nil))
+	// Must cannot panic on things that implement error but are nil
+	require.Equal(t, 1, Must(1, validate()))
 }
 
 func ExampleDiff() {


### PR DESCRIPTION
An example of a time where this would have been nice is operating with rationals when you know the numerator is not 0, but you still have to deal with the signature of `RatReciprocal() (*big.Rat, error)`.

This can also take the place of some of the other `Must.*` in the codebase, as any calls to them can just be replaced with `MustParse(.) === Must(Parse(.))`.