### PR TITLE
increase size of pre-allocated buffer for full stack traces

### DIFF
--- a/util/stackutil/stack.go
+++ b/util/stackutil/stack.go
@@ -14,7 +14,7 @@ var full = struct {
 	buf   []byte
 	mutex sync.Mutex
 }{
-	buf: make([]byte, 1024*1024),
+	buf: make([]byte, 10*1024*1024),
 }
 
 // FullStack creates a full dump of all the stack traces of all current


### PR DESCRIPTION
* practical examples showed sizes between 600KB to 8MB