### PR TITLE
fix ifutil.IsZero / IsEmpty

### DIFF
--- a/util/ifutil/ifutil.go
+++ b/util/ifutil/ifutil.go
@@ -68,8 +68,7 @@ func IsEmpty(obj interface{}) bool {
 		return IsEmpty(val.Elem().Interface())
 	// for all other types, compare against the zero value
 	default:
-		zero := reflect.Zero(val.Type())
-		return reflect.DeepEqual(obj, zero.Interface())
+		return IsZero(obj)
 	}
 }
 
@@ -86,9 +85,16 @@ func FirstNonEmpty[T any](objs ...T) T {
 }
 
 // IsZero returns true if the given argument is the zero value of its type, false otherwise.
-func IsZero[T comparable](t T) bool {
-	var zero T
-	return t == zero
+func IsZero(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	val := reflect.ValueOf(v)
+	if val.IsValid() {
+		return val.IsZero()
+	}
+	// If the value is not valid, it means it's the zero reflect.Value.
+	return true
 }
 
 // FirstNonZero returns the first argument that is not the zero value as determined by the IsZero function. Returns the

--- a/util/ifutil/ifutil_test.go
+++ b/util/ifutil/ifutil_test.go
@@ -156,6 +156,12 @@ func TestIsEmpty(t *testing.T) {
 	asrt.False(IsEmpty(true))
 	asrt.False(IsEmpty(int8(3)))
 	asrt.False(IsEmpty(int16(-1)))
+
+	var vs = ""
+	var vi interface{}
+	vi = vs
+	asrt.True(IsEmpty(vs))
+	asrt.True(IsEmpty(vi))
 }
 
 func TestFirstNonEmpty(t *testing.T) {
@@ -223,6 +229,12 @@ func TestIsZero(t *testing.T) {
 	asrt.False(IsZero(true))
 	asrt.False(IsZero(int8(3)))
 	asrt.False(IsZero(int16(-1)))
+
+	var vs = ""
+	var vi interface{}
+	vi = vs
+	asrt.True(IsZero(vs))
+	asrt.True(IsZero(vi))
 }
 
 func TestFirstNonZero(t *testing.T) {


### PR DESCRIPTION
detect a zero value even if contained in an empty interface{}. See unit tests.