### PR TITLE
add generic versions of lru.Cache, lru.ExpiringCache, lru.RefCache

### DIFF
--- a/util/lru/expiring.go
+++ b/util/lru/expiring.go
@@ -131,7 +131,7 @@ func (c *TypedExpiringCache[K, V]) checkAge(now utc.UTC, evict ...func(val Expir
 func (c *TypedExpiringCache[K, V]) isExpired(val *expiringEntry[V], now utc.UTC) bool {
 	age := now.Sub(val.ts)
 	if age >= c.maxAge {
-		traceutil.Span().Attribute("expired_entry_age", age)
+		traceutil.Span().Attribute("expired_entry_age", duration.Spec(age).RoundTo(1))
 		return true
 	}
 	return false

--- a/util/lru/expiring.go
+++ b/util/lru/expiring.go
@@ -11,11 +11,16 @@ import (
 
 // NewExpiringCache creates a new ExpiringCache.
 func NewExpiringCache(maxSize int, maxAge duration.Spec) *ExpiringCache {
-	cache := Nil()
+	return NewTypedExpiringCache[any, any](maxSize, maxAge)
+}
+
+// NewTypedExpiringCache creates a new TypedExpiringCache.
+func NewTypedExpiringCache[K any, V any](maxSize int, maxAge duration.Spec) *TypedExpiringCache[K, V] {
+	cache := TypedNil[K, *expiringEntry[V]]()
 	if maxSize > 0 && maxAge > 0 {
-		cache = New(maxSize)
+		cache = NewTyped[K, *expiringEntry[V]](maxSize)
 	}
-	res := &ExpiringCache{
+	res := &TypedExpiringCache[K, V]{
 		cache:  cache,
 		maxAge: maxAge.Duration(),
 	}
@@ -23,35 +28,44 @@ func NewExpiringCache(maxSize int, maxAge duration.Spec) *ExpiringCache {
 	return res
 }
 
-// ExpiringCache is an LRU cache that evicts entries from the cache when they
-// reach the configured max age. Expired entries are evicted lazily, i.e. only
-// when requested, and hence not garbage collected otherwise.
-type ExpiringCache struct {
-	cache            *Cache
+// ExpiringCache is an LRU cache that evicts entries from the cache when they reach the configured max age. Expired
+// entries are evicted lazily, and hence not garbage collected otherwise. Eviction occurs when
+//   - requesting an expired entry through Get, GetOrCreate, Remove
+//   - calling Len or Entries
+type ExpiringCache = TypedExpiringCache[any, any]
+
+// TypedExpiringCache is a typed LRU cache that evicts entries from the cache when they reach the configured max age.
+// Expired entries are evicted lazily, and hence not garbage collected otherwise. Eviction occurs when
+//   - requesting an expired entry through Get, GetOrCreate, Remove
+//   - calling Len or Entries
+type TypedExpiringCache[K any, V any] struct {
+	cache            *TypedCache[K, *expiringEntry[V]]
 	maxAge           time.Duration
 	resetAgeOnAccess bool // if true, resets the entries age to 0 on access
 }
 
 // WithMode sets the cache's construction mode.
-func (c *ExpiringCache) WithMode(mode ConstructionMode) *ExpiringCache {
+func (c *TypedExpiringCache[K, V]) WithMode(mode ConstructionMode) *TypedExpiringCache[K, V] {
 	c.cache.WithMode(mode)
 	return c
 }
 
 // WithResetAgeOnAccess turns resetting of an entry's age on access on or off.
-func (c *ExpiringCache) WithResetAgeOnAccess(set bool) *ExpiringCache {
+func (c *TypedExpiringCache[K, V]) WithResetAgeOnAccess(set bool) *TypedExpiringCache[K, V] {
 	c.resetAgeOnAccess = set
 	return c
 }
 
 // WithEvictHandler sets the given evict handler.
-func (c *ExpiringCache) WithEvictHandler(onEvicted func(key interface{}, value interface{})) *ExpiringCache {
-	c.cache.WithEvictHandler(onEvicted)
+func (c *TypedExpiringCache[K, V]) WithEvictHandler(onEvicted func(key K, value ExpiringEntry[V])) *TypedExpiringCache[K, V] {
+	c.cache.WithEvictHandler(func(key K, value *expiringEntry[V]) {
+		onEvicted(key, value)
+	})
 	return c
 }
 
 // WithName sets the cache's name and returns itself for call chaining.
-func (c *ExpiringCache) WithName(name string) *ExpiringCache {
+func (c *TypedExpiringCache[K, V]) WithName(name string) *TypedExpiringCache[K, V] {
 	if c == nil {
 		return nil
 	}
@@ -71,20 +85,21 @@ func (c *ExpiringCache) WithName(name string) *ExpiringCache {
 //   - If evict functions are passed and a non-expired cache entry exists, then
 //     the first evict function is invoked with the cached value. If it returns
 //     true, the value is discarded from the cache and the constructor is called.
-func (c *ExpiringCache) GetOrCreate(
-	key interface{},
-	constructor func() (interface{}, error),
-	evict ...func(val interface{}) bool) (val interface{}, evicted bool, err error) {
+func (c *TypedExpiringCache[K, V]) GetOrCreate(
+	key K,
+	constructor func() (V, error),
+	evict ...func(val ExpiringEntry[V]) bool) (val V, evicted bool, err error) {
 
 	now := utc.Now()
-	val, evicted, err = c.cache.GetOrCreate(
+	var entry *expiringEntry[V]
+	entry, evicted, err = c.cache.GetOrCreate(
 		key,
-		func() (interface{}, error) {
+		func() (*expiringEntry[V], error) {
 			val, err := constructor()
 			if err != nil {
 				return nil, err
 			}
-			return &expiringEntry{
+			return &expiringEntry[V]{
 				val: val,
 				ts:  now,
 			}, nil
@@ -92,18 +107,19 @@ func (c *ExpiringCache) GetOrCreate(
 		c.checkAge(now, evict...),
 	)
 	if err != nil {
-		return nil, evicted, err
+		var zero V
+		return zero, evicted, err
 	}
-	return val.(*expiringEntry).val, evicted, nil
+	return entry.val, evicted, nil
 }
 
-func (c *ExpiringCache) checkAge(now utc.UTC, evict ...func(val interface{}) bool) func(val interface{}) bool {
-	return func(val interface{}) bool {
+func (c *TypedExpiringCache[K, V]) checkAge(now utc.UTC, evict ...func(val ExpiringEntry[V]) bool) func(val *expiringEntry[V]) bool {
+	return func(val *expiringEntry[V]) bool {
 		if c.isExpired(val, now) {
 			return true
 		}
 		if c.resetAgeOnAccess {
-			val.(*expiringEntry).ts = now
+			val.ts = now
 		}
 		if len(evict) > 0 {
 			return evict[0](val)
@@ -112,8 +128,8 @@ func (c *ExpiringCache) checkAge(now utc.UTC, evict ...func(val interface{}) boo
 	}
 }
 
-func (c *ExpiringCache) isExpired(val interface{}, now utc.UTC) bool {
-	age := now.Sub(val.(*expiringEntry).ts)
+func (c *TypedExpiringCache[K, V]) isExpired(val *expiringEntry[V], now utc.UTC) bool {
+	age := now.Sub(val.ts)
 	if age >= c.maxAge {
 		traceutil.Span().Attribute("expired_entry_age", age)
 		return true
@@ -123,17 +139,18 @@ func (c *ExpiringCache) isExpired(val interface{}, now utc.UTC) bool {
 
 // Get returns the value stored for the given key and true if the key exists,
 // nil and false if the key does not exist or has expired.
-func (c *ExpiringCache) Get(key interface{}) (interface{}, bool) {
+func (c *TypedExpiringCache[K, V]) Get(key K) (V, bool) {
 	val, ok := c.cache.getOrEvict(key, true, c.checkAge(utc.Now()), nil)
 	if ok {
-		return val.(*expiringEntry).val, true
+		return val.val, true
 	}
-	return nil, false
+	var zero V
+	return zero, false
 }
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
-func (c *ExpiringCache) Add(key, value interface{}) bool {
-	return c.cache.Add(key, &expiringEntry{
+func (c *TypedExpiringCache[K, V]) Add(key K, value V) bool {
+	return c.cache.Add(key, &expiringEntry[V]{
 		val: value,
 		ts:  utc.Now(),
 	})
@@ -143,15 +160,15 @@ func (c *ExpiringCache) Add(key, value interface{}) bool {
 // It returns two booleans:
 //   - new: true if the key is new, false if it already existed and the entry was updated
 //   - evicted: true if an eviction occurred.
-func (c *ExpiringCache) Update(key, value interface{}) (new bool, evicted bool) {
-	return c.cache.UpdateFn(key, func(entry interface{}) interface{} {
-		if en, ok := entry.(*expiringEntry); ok {
-			en.val = value
-			en.ts = utc.Now()
+func (c *TypedExpiringCache[K, V]) Update(key K, value V) (new bool, evicted bool) {
+	return c.cache.UpdateFn(key, func(entry *expiringEntry[V]) *expiringEntry[V] {
+		if entry != nil {
+			entry.val = value
+			entry.ts = utc.Now()
 			return entry
 		}
 
-		return &expiringEntry{
+		return &expiringEntry[V]{
 			val: value,
 			ts:  utc.Now(),
 		}
@@ -159,12 +176,12 @@ func (c *ExpiringCache) Update(key, value interface{}) (new bool, evicted bool) 
 }
 
 // Remove removes the entry with the given key.
-func (c *ExpiringCache) Remove(key interface{}) {
+func (c *TypedExpiringCache[K, V]) Remove(key K) {
 	c.cache.Remove(key)
 }
 
 // Len returns the number of entries in the cache after evicting any expired entries.
-func (c *ExpiringCache) Len() (len int) {
+func (c *TypedExpiringCache[K, V]) Len() (len int) {
 	now := utc.Now()
 	c.cache.runWithWriteLock(func() {
 		c.evictExpired(now)
@@ -174,16 +191,16 @@ func (c *ExpiringCache) Len() (len int) {
 }
 
 // Entries returns all (non-expired) entries in the cache from oldest to newest.
-func (c *ExpiringCache) Entries() (entries []ExpiringEntry) {
+func (c *TypedExpiringCache[K, V]) Entries() (entries []ExpiringEntry[V]) {
 	now := utc.Now()
 	c.cache.runWithWriteLock(func() {
 		c.evictExpired(now)
 		keys := c.cache.lru.Keys()
-		entries = make([]ExpiringEntry, len(keys))
+		entries = make([]ExpiringEntry[V], len(keys))
 		for idx, key := range keys {
 			val, ok := c.cache.lru.Get(key)
 			if ok {
-				ee := val.(*expiringEntry)
+				ee := val.(*expiringEntry[V])
 				clone := *ee
 				entries[idx] = &clone
 			}
@@ -193,23 +210,23 @@ func (c *ExpiringCache) Entries() (entries []ExpiringEntry) {
 }
 
 // Purge removes all entries from the cache.
-func (c *ExpiringCache) Purge() {
+func (c *TypedExpiringCache[K, V]) Purge() {
 	c.cache.Purge()
 }
 
 // EvictExpired removes all expired entries.
-func (c *ExpiringCache) EvictExpired() {
+func (c *TypedExpiringCache[K, V]) EvictExpired() {
 	c.Len()
 }
 
 // evictExpired removes all expired entries
-func (c *ExpiringCache) evictExpired(now utc.UTC) {
+func (c *TypedExpiringCache[K, V]) evictExpired(now utc.UTC) {
 	for {
 		_, val, ok := c.cache.lru.GetOldest()
 		if !ok {
 			return
 		}
-		if c.isExpired(val, now) {
+		if c.isExpired(val.(*expiringEntry[V]), now) {
 			c.cache.lru.RemoveOldest()
 		} else {
 			return
@@ -218,30 +235,30 @@ func (c *ExpiringCache) evictExpired(now utc.UTC) {
 }
 
 // Metrics returns a copy of the cache's runtime properties.
-func (c *ExpiringCache) Metrics() Metrics {
+func (c *TypedExpiringCache[K, V]) Metrics() Metrics {
 	return c.cache.Metrics()
 }
 
 // CollectMetrics returns a copy of the cache's runtime properties.
-func (c *ExpiringCache) CollectMetrics() jsonutil.GenericMarshaler {
+func (c *TypedExpiringCache[K, V]) CollectMetrics() jsonutil.GenericMarshaler {
 	m := c.Metrics()
 	return &m
 }
 
-type ExpiringEntry interface {
-	Value() interface{}
+type ExpiringEntry[V any] interface {
+	Value() V
 	LastUpdated() utc.UTC
 }
 
-type expiringEntry struct {
-	val interface{}
+type expiringEntry[V any] struct {
+	val V
 	ts  utc.UTC
 }
 
-func (e *expiringEntry) Value() interface{} {
+func (e *expiringEntry[V]) Value() V {
 	return e.val
 }
 
-func (e *expiringEntry) LastUpdated() utc.UTC {
+func (e *expiringEntry[V]) LastUpdated() utc.UTC {
 	return e.ts
 }

--- a/util/lru/expiring_test.go
+++ b/util/lru/expiring_test.go
@@ -81,7 +81,7 @@ func testExpiringCache(t *testing.T, assertEntries func(c *lru.ExpiringCache, va
 	})
 
 	cache := lru.NewExpiringCache(10, duration.Spec(5*time.Second))
-	cache.WithEvictHandler(func(key interface{}, value interface{}) {
+	cache.WithEvictHandler(func(key interface{}, entry lru.ExpiringEntry[any]) {
 		evictedCount++
 	})
 

--- a/util/lru/ref_cache.go
+++ b/util/lru/ref_cache.go
@@ -13,13 +13,26 @@ import (
 	"github.com/eluv-io/log-go"
 )
 
+// NewRefCache creates a new untyped RefCache with the given max size and optional callback.
 func NewRefCache(
 	maxSize int,
 	callback Callback) *RefCache {
 
-	c := &RefCache{
+	return NewTypedRefCache[string, io.Closer](maxSize, callback)
+}
+
+// NewTypedRefCache creates a new TypedRefCache with the given max size and optional callback.
+func NewTypedRefCache[K comparable, V io.Closer](
+	maxSize int,
+	callback Callback) *TypedRefCache[K, V] {
+
+	if callback == nil {
+		callback = NoopCallback{}
+	}
+
+	c := &TypedRefCache[K, V]{
 		callback: callback,
-		active:   make(map[string]*entry),
+		active:   make(map[K]*entry[V]),
 		metrics:  MakeMetrics(),
 	}
 	if maxSize > 0 {
@@ -29,7 +42,8 @@ func NewRefCache(
 	return c
 }
 
-type Constructor func() (io.Closer, error)
+// Constructor is a function to create values.
+type Constructor[V io.Closer] func() (V, error)
 
 type Callback interface {
 	OnOpen()    // called when a new resource is created (and added to the cache)
@@ -38,7 +52,10 @@ type Callback interface {
 	OnRelease() // called when a resource is release
 }
 
-// RefCache implements a two-tier cache for shared resources that implement an
+// RefCache is an untyped version of TypedRefCache.
+type RefCache = TypedRefCache[string, io.Closer]
+
+// TypedRefCache implements a two-tier cache for shared resources that implement an
 // explicit open/close semantic.
 //
 // A client opens (or creates) a resource with a call to GetOrCreate(). The
@@ -58,42 +75,42 @@ type Callback interface {
 // Resources are created through a constructor function passed to GetOrCreate()
 // and closed with a call to their Close() function (resources must implement
 // the io.Closer interface).
-type RefCache struct {
-	active   map[string]*entry // all active entries
-	lru      *simplelru.LRU    // the LRU cache for inactive entries
-	mutex    sync.Mutex        // mutex for access to active map
+type TypedRefCache[K comparable, V io.Closer] struct {
+	active   map[K]*entry[V] // all active entries
+	lru      *simplelru.LRU  // the LRU cache for inactive entries
+	mutex    sync.Mutex      // mutex for access to active map
 	callback Callback
 	metrics  Metrics
 }
 
-type entry struct {
+type entry[V io.Closer] struct {
 	mutex    sync.Mutex
-	resource io.Closer
+	resource V
 	refCount int
 	error    error // a creation error
 }
 
-func (e *entry) validate() (resource io.Closer, err error) {
+func (e *entry[V]) validate() (resource V, err error) {
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 	return e.resource, e.error
 }
 
-func (c *RefCache) WithName(name string) {
+func (c *TypedRefCache[K, V]) WithName(name string) {
 	c.metrics.Name = name
 }
 
-func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}, error) {
+func (c *TypedRefCache[K, V]) GetOrCreate(key K, constructor Constructor[V]) (V, error) {
 	var val interface{}
-	var ent *entry
+	var ent *entry[V]
 	var exists bool
 	var err error
 
-	span := traceutil.StartSpan("lru.RefCache.GetOrCreate")
+	span := traceutil.StartSpan("lru.TypedRefCache.GetOrCreate")
 	defer span.End()
 	if span.IsRecording() {
 		orgConstructor := constructor
-		constructor = func() (io.Closer, error) {
+		constructor = func() (V, error) {
 			span := traceutil.StartSpan("constructor")
 			defer span.End()
 			return orgConstructor()
@@ -117,14 +134,14 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 			}
 			if exists {
 				// it's a cached resource in the LRU
-				ent = val.(*entry)
+				ent = val.(*entry[V])
 				ent.refCount = 1
 				// add it back to the active map
 				c.active[key] = ent
 			} else {
 				// it doesn't exist - create the wrapper entry, lock it and add
 				// it to the active map. The actual resource is created below.
-				ent = &entry{refCount: 1}
+				ent = &entry[V]{refCount: 1}
 				ent.mutex.Lock()
 				c.active[key] = ent
 				c.metrics.Add()
@@ -139,7 +156,7 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 		// validate() locks the mutex, this waits until the creation has
 		// finished. If there is an error in the (concurrent) creation, we
 		// return that error as well.
-		val, err = ent.validate()
+		res, err := ent.validate()
 		c.mutex.Lock()
 		if err != nil {
 			c.metrics.Error()
@@ -148,7 +165,7 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 			c.callback.OnGet()
 		}
 		c.mutex.Unlock()
-		return val, err
+		return res, err
 	}
 
 	// the wrapper entry now exists, but not the resource... create it
@@ -156,7 +173,7 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				err = errors.E("RefCache entry constructor", errors.K.Internal, "panic", r)
+				err = errors.E("TypedRefCache entry constructor", errors.K.Internal, "panic", r)
 			}
 		}()
 		ent.resource, err = constructor()
@@ -173,7 +190,8 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 		c.metrics.Error()
 		c.mutex.Unlock()
 
-		return nil, err
+		var zero V
+		return zero, err
 	}
 
 	ent.mutex.Unlock()
@@ -185,14 +203,14 @@ func (c *RefCache) GetOrCreate(key string, constructor Constructor) (interface{}
 
 // Release releases the given resource. Returns true if an eviction from the
 // cache occurred (usually another entry than the one being released...)
-func (c *RefCache) Release(key string) (evicted bool) {
+func (c *TypedRefCache[K, V]) Release(key K) (evicted bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	ent, found := c.active[key]
 	if !found {
 		// a cache usage error
-		log.Warn("RefCache: release called for unknown resource!", "key", key)
+		log.Warn("TypedRefCache: release called for unknown resource!", "key", key)
 		return
 	}
 
@@ -200,7 +218,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 	if err != nil {
 		// the entry is in the process of being created... that's similar to the
 		// error above
-		log.Warn("RefCache: release called for resource under construction!", "key", key)
+		log.Warn("TypedRefCache: release called for resource under construction!", "key", key)
 		return
 	}
 
@@ -213,7 +231,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 
 	if ent.refCount < 0 {
 		// that should never happen and would indicate a bug in the cache implementation
-		log.Error("RefCache: reference count negative!", "key", key, "ref_count", ent.refCount)
+		log.Error("TypedRefCache: reference count negative!", "key", key, "ref_count", ent.refCount)
 		ent.refCount = 0
 	}
 
@@ -230,7 +248,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 	return evicted
 }
 
-func (c *RefCache) Purge() {
+func (c *TypedRefCache[K, V]) Purge() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -244,30 +262,30 @@ func (c *RefCache) Purge() {
 }
 
 // Metrics returns a copy of the cache's runtime properties.
-func (c *RefCache) Metrics() Metrics {
+func (c *TypedRefCache[K, V]) Metrics() Metrics {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	return c.metrics.Copy()
 }
 
 // CollectMetrics returns a copy of the cache's runtime properties.
-func (c *RefCache) CollectMetrics() jsonutil.GenericMarshaler {
+func (c *TypedRefCache[K, V]) CollectMetrics() jsonutil.GenericMarshaler {
 	m := c.Metrics()
 	return &m
 }
 
-func (c *RefCache) onEvict(key interface{}, val interface{}) {
-	c.closeEntry(key, val.(*entry))
+func (c *TypedRefCache[K, V]) onEvict(key interface{}, val interface{}) {
+	c.closeEntry(key.(K), val.(*entry[V]))
 }
 
-func (c *RefCache) closeEntry(key interface{}, ent *entry) {
+func (c *TypedRefCache[K, V]) closeEntry(key K, ent *entry[V]) {
 	// close entry is always called holding c.mutex!
 	res, err := ent.validate()
 	if err != nil {
-		log.Warn("RefCache: closeEntry called for invalid resource!", "key", key)
+		log.Warn("TypedRefCache: closeEntry called for invalid resource!", "key", key)
 		return
 	}
-	if _, found := c.active[key.(string)]; !found {
+	if _, found := c.active[key]; !found {
 		// the resource is only removed from the cache if it's gone from the
 		// lru AND the active map.
 		_ = res.Close()
@@ -275,3 +293,12 @@ func (c *RefCache) closeEntry(key interface{}, ent *entry) {
 		c.callback.OnClose()
 	}
 }
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+type NoopCallback struct{}
+
+func (q NoopCallback) OnOpen()    {}
+func (q NoopCallback) OnClose()   {}
+func (q NoopCallback) OnGet()     {}
+func (q NoopCallback) OnRelease() {}

--- a/util/sessiontracker/tracker.go
+++ b/util/sessiontracker/tracker.go
@@ -125,7 +125,7 @@ func (t *tracker) Purge() {
 	t.sessions.Purge()
 }
 
-func (t *tracker) onEvicted(key interface{}, value interface{}) {
+func (t *tracker) onEvicted(key interface{}, value lru.ExpiringEntry[interface{}]) {
 	// called from Update or SessionMetrics while holding mutex
 	t.metrics.Removed++
 }


### PR DESCRIPTION
This PR adds 

* `lru.TypedCache[K any, V any]`
* `lru.TypedExpiringCache[K any, V any]`
* `lru.TypedRefCache[K comparable, V io.Closer]`

with their corresponding constructors. The existing non-generic versions remain as type aliases of the typed versions with their respective constructors for backwards-compatibility:

* `type Cache = TypedCache[any, any]`
* `type ExpiringCache = TypedExpiringCache[any, any]`
* `type RefCache = TypedRefCache[string, io.Closer]`
