### PR TITLE
increase CBOR limits for array elements, map keys, nested objects

### DIFF
--- a/format/codecs/codecs.go
+++ b/format/codecs/codecs.go
@@ -181,6 +181,9 @@ func makeCborV2Codec() Codec {
 	dec, err := cbor.DecOptions{
 		DefaultMapType:          reflect.TypeOf((map[string]interface{})(nil)),
 		HandleTagForUnmarshaler: true,
+		MaxArrayElements:        1024 * 1024, // github.com/fxamacker/cbor/v2 default is 128 * 1024
+		MaxMapPairs:             1024 * 1024, // github.com/fxamacker/cbor/v2 default is 128 * 1024
+		MaxNestedLevels:         100,         // github.com/fxamacker/cbor/v2 default is 32
 	}.DecModeWithTags(tagSet)
 	if err != nil {
 		log.Fatal("failed to create cbor decoder mode", err)


### PR DESCRIPTION
Slack message from @elv-marc: The MGM assets search started failing a few days ago and the message seems to indicate that we hit some upper limits:

```
2025-07-02T09:48:41.693Z_-_20:ERROR-(elv-client-js#HttpClient)_-_"{
   "name": "ElvHttpClientError",
   "status": 500,
   "statusText": "Internal Server Error",
   "message": "Internal Server Error",
   "url": "https://host-76-74-35-67.contentfabric.io/qid/iq__7y7ruZHzDZCemWzUxoj3AviSmyC",
   "body": {
     "errors": [
       {
         "op": "Q.Create",
         "kind": "I/O error",
         "qlib_id": "ilib2XX6yS9S8bgAeLVxDGKeoNcNVckN",
         "req": {
           "id": "iq__7y7ruZHzDZCemWzUxoj3AviSmyC",
           "type": "",
           "meta": {},
           "copy_from": ""
         },
         "cause": {
           "op": "save structured data",
           "kind": "I/O error",
           "cause": {
             "op": "LoadQstruct",
             "kind": "unclassified error",
             "write_token": "tqw__HSQEyfqbmkdk6NpjYL7BKgsmk6Y1JWUamK7AByA2CDHuLwiSqjV9vVhELyVbREquvgtwwRNLAw7WUupji9Y",
             "cause": "cbor: exceeded max number of key-value pairs 131072 for CBOR map"
           }
         },
         "stacktrace": [
           "github.com/qluvio/content-fabric/qapi/qstruct.go:43                              loadQstruct()",
           "github.com/qluvio/content-fabric/qapi/qwriter.go:789                             (*writerSDS).Store()",
           "github.com/qluvio/content-fabric/sd/direct.go:288                                (*direct).save()",
           "github.com/qluvio/content-fabric/sd/direct.go:289                                (*direct).save()",
           "github.com/qluvio/content-fabric/sd/direct.go:117                                (*direct).Merge()",
           "github.com/qluvio/content-fabric/sd/atomic.go:34                                 (*atomic).Merge()",
           "github.com/qluvio/content-fabric/qfab/daemon/simple/q.go:132                     (*q).CreateContent()",
           "github.com/qluvio/content-fabric/qfab/daemon/simple/q.go:134                     (*q).CreateContent()",
           "github.com/qluvio/content-fabric/qfab/handlers/q.go:390                          init.func141.(*QHF).QModify.1()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/authentication.go:368    (*authMiddleware).tokenAuthHandler()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/compress.go:91           Compress.(*compressHF).Middleware.func2()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/usage.go:61              UsageHandler.func1()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/http_stats_logger.go:227 (*statsLogger).HttpStatsLogger()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/error.go:32              ErrorHandler.func1()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/tracing.go:84            TraceHandler.func1()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/qluvio/content-fabric/qfab/daemon/middleware/recovery.go:51           Recovery.func1()",
           "github.com/gin-gonic/gin@v1.7.7/context.go:168                                   (*Context).Next()",
           "github.com/gin-gonic/gin@v1.7.7/gin.go:555                                       (*Engine).handleHTTPRequest()",
           "github.com/gin-gonic/gin@v1.7.7/gin.go:511                                       (*Engine).ServeHTTP()"
         ]
       }
     ]
   },
   "requestParams": {
     "method": "POST",
     "headers": {
       "Authorization": "Bearer eyJxc3BhY2VfaWQiOiJpc3BjMlJVb1JlOWVSMnYzM0hBUlFVVlNwMXJZWHp3MSIsImFkZHIiOiIweGI4NTgwNzVjYjM2OGVmMzdhMmU2NmE1MjljMDY4YjNiN2M5YTE5YzgiLCJ0eF9pZCI6IjB4YTBkZGNlNmZlNjkzOTczMjAyZWU0MWNhMWEwYjA0YTA3NjIzMzQyZGZmYmY4NDdiMTY5ZTVkMzc0OTU0MzhhMiIsInFsaWJfaWQiOiJpbGliMlhYNnlTOVM4YmdBZUxWeERHS2VvTmNOVmNrTiJ9.RVMyNTZLX01odUNUS2J6QnFIdVVyYVMzamFUQzE5REM2NkZUMWFtRXg3SjhUZGJyZDVCYUpHTFN4ZUxLM0Jmc0FIYnVyc2dCUm1nVTVNRm5YUHM0YnpaUUFoNXNXUnF1",
       "Accept": "application/json",
       "Content-type": "application/json"
     },
     "body": "{}"
   }
 }"
```