### PR TITLE
add a sliding window data struct for gathering basic statics

### DIFF
--- a/collections/slidingwindow/sliding_window.go
+++ b/collections/slidingwindow/sliding_window.go
@@ -1,0 +1,225 @@
+package slidingwindow
+
+import (
+	"math"
+	"slices"
+
+	"golang.org/x/exp/constraints"
+
+	"github.com/eluv-io/common-go/util/ifutil"
+	"github.com/eluv-io/utc-go"
+)
+
+type Number interface {
+	constraints.Integer | constraints.Float
+}
+
+func New[T Number](capacity int) *SlidingWindow[T] {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &SlidingWindow[T]{
+		capacity: capacity,
+		entries:  make([]*entry[T], capacity),
+		oldest:   0,
+		count:    0,
+	}
+}
+
+// SlidingWindow is a data structure that maintains a fixed-capacity sliding window of the last N values added to it.
+// It maintains the mean and variance of the values that are added (and removed) progressively using [Welford's
+// algorithm].
+//
+// Values are stored in a circular buffer and timestamped at insertion. The Statistics method can extract statistical
+// summaries (mean, variance, min, max, quantiles, etc.) for all or a subset of values, optionally filtered by a start
+// time.
+//
+// [Welford's algorithm]: https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford%27s_online_algorithm
+//
+type SlidingWindow[T Number] struct {
+	entries  []*entry[T] // the values in the series, stored in a circular buffer
+	capacity int         // the maximum number of values in the series
+	oldest   int         // index of the oldest value
+	count    int         // number of values in the series
+	mean     float64     // mean of values in the series
+	m2       float64     // sum of squares of differences from the current mean
+}
+
+// Add adds a new value to the sliding window. If the window is full, it replaces the oldest value with the new one.
+func (s *SlidingWindow[T]) Add(value T) {
+	newValue := float64(value)
+
+	if s.count < s.capacity {
+		s.entries[s.count] = &entry[T]{value: value, ts: utc.Now()}
+		s.count++
+
+		// Update mean and m2 using Welford's method
+		if s.count == 1 {
+			s.mean = newValue
+			s.m2 = 0.0
+		} else {
+			delta := newValue - s.mean
+			s.mean += delta / float64(s.count)
+			s.m2 += delta * (newValue - s.mean)
+		}
+	} else {
+		oldestEntry := s.entries[s.oldest]
+		oldValue := float64(oldestEntry.value)
+
+		// replace the oldest value with the new one
+		oldestEntry.value = value
+		oldestEntry.ts = utc.Now()
+		s.oldest = (s.oldest + 1) % s.capacity
+
+		// Update mean and m2 for both removal and addition
+		deltaRemove := oldValue - s.mean
+		s.mean -= deltaRemove / float64(s.capacity-1)
+		s.m2 -= deltaRemove * (oldValue - s.mean)
+
+		deltaAdd := newValue - s.mean
+		s.mean += deltaAdd / float64(s.capacity)
+		s.m2 += deltaAdd * (newValue - s.mean)
+	}
+
+}
+
+// Count returns the number of values currently in the sliding window.
+func (s *SlidingWindow[T]) Count() int {
+	return s.count
+}
+
+// Mean returns the current mean of the values in the sliding window.
+func (s *SlidingWindow[T]) Mean() float64 {
+	return s.mean
+}
+
+// Variance returns the current variance of the values in the sliding window.
+func (s *SlidingWindow[T]) Variance() float64 {
+	if s.count == 1 {
+		return 0.0
+	}
+	return s.m2 / float64(s.count-1)
+}
+
+// Statistics returns basic statistics of the values in the sliding window, optionally filtered by the specified start
+// time.
+func (s *SlidingWindow[T]) Statistics(startingAt ...utc.UTC) *Statistics[T] {
+	if s.count == 0 {
+		var zero T
+		return &Statistics[T]{
+			mean:     0.0,
+			variance: 0.0,
+			min:      zero,
+			max:      zero,
+		}
+	}
+
+	start := ifutil.FirstOrDefault(startingAt, utc.Zero)
+	var sum T
+	var sum2 float64
+	sortedValues := make([]T, 0, s.count)
+	for i := 0; i < s.count; i++ {
+		e := s.entries[i]
+		if e.ts.Before(start) {
+			continue // skip entries before the starting time
+		}
+		value := e.value
+		sortedValues = append(sortedValues, value)
+		sum += value
+		diff := float64(value) - s.mean
+		sum2 += diff * diff
+	}
+	slices.Sort(sortedValues)
+
+	count := len(sortedValues)
+	return &Statistics[T]{
+		sorted:   sortedValues,
+		mean:     float64(sum) / float64(count),
+		min:      sortedValues[0],
+		max:      sortedValues[count-1],
+		variance: sum2 / float64(count-1),
+	}
+}
+
+type entry[T any] struct {
+	value T       // the value of the entry
+	ts    utc.UTC // the time of entry assignment
+}
+
+// Statistics provides statistical summaries for a set of numeric values in a SlidingWindow.
+// It includes the sorted values, mean, variance, minimum, maximum, and quantile calculations.
+type Statistics[T Number] struct {
+	sorted   []T // the values in the series
+	mean     float64
+	variance float64
+	min      T
+	max      T
+}
+
+// Min returns the minimum value in the series.
+func (s *Statistics[T]) Min() T {
+	return s.min
+}
+
+// Max returns the maximum value in the series.
+func (s *Statistics[T]) Max() T {
+	return s.max
+}
+
+// Mean returns the mean (average) of the values in the series.
+func (s *Statistics[T]) Mean() float64 {
+	return s.mean
+}
+
+// Variance returns the variance of the values in the series.
+func (s *Statistics[T]) Variance() float64 {
+	return s.variance
+}
+
+// Stddev returns the standard deviation of the values in the series.
+func (s *Statistics[T]) Stddev() float64 {
+	return math.Sqrt(s.variance)
+}
+
+// Quantile returns the value at the specified quantile (0.0 to 1.0) in the sorted series using the "nearest rank"
+// method.
+func (s *Statistics[T]) Quantile(q float64) T {
+	var zero T
+	if q < 0 || q > 1 {
+		return zero
+	}
+	count := len(s.sorted)
+	if count == 0 {
+		return zero
+	}
+
+	// Calculate the index in the sorted order
+	index := int(math.Ceil(q * float64(count-1)))
+	if index >= count {
+		index = count - 1
+	}
+
+	return s.sorted[index]
+}
+
+// QuantileInterpolated returns the value at the specified quantile (0.0 to 1.0) in the sorted series using linear
+// interpolation.
+func (s *Statistics[T]) QuantileInterpolated(q float64) T {
+	if q < 0 || q > 1 {
+		return 0
+	}
+	count := len(s.sorted)
+	if count == 0 {
+		return 0
+	}
+
+	pos := q * float64(count-1)
+	v1 := s.sorted[int(math.Floor(pos))]
+	v2 := s.sorted[int(math.Ceil(pos))]
+	return T(float64(v1) + (float64(v2)-float64(v1))*(pos-math.Floor(pos)))
+}
+
+// Count returns the number of values in the series.
+func (s *Statistics[T]) Count() int {
+	return len(s.sorted)
+}

--- a/collections/slidingwindow/sliding_window_test.go
+++ b/collections/slidingwindow/sliding_window_test.go
@@ -44,11 +44,18 @@ func TestSlidingWindow(t *testing.T) {
 	add(2)
 	split := clock.Now()
 	add(3)
+
+	// check mean and count
+	require.Equal(t, 2.0, sw.Mean())
+	require.Equal(t, 2.0/3.0, sw.Variance())
+	require.Equal(t, 3, sw.Count())
+
 	add(4)
 	add(5)
 
-	// Check the mean and count
+	// check mean and count
 	require.Equal(t, 3.0, sw.Mean())
+	require.Equal(t, 2.0, sw.Variance())
 	require.Equal(t, 5, sw.Count())
 
 	{
@@ -73,10 +80,11 @@ func TestSlidingWindow(t *testing.T) {
 	}
 
 	{
-		// validate stats of subset
+		// validate stats of subset [3,4,5]
 		sts := sw.Statistics(split)
 		require.Equal(t, 3, sts.Count())
 		require.Equal(t, 4.0, sts.Mean())
+		require.Equal(t, 2.0/3.0, sts.Variance())
 		require.Equal(t, 3, sts.Min())
 		require.Equal(t, 5, sts.Max())
 		require.Equal(t, 0, sts.Quantile(-1.0))

--- a/collections/slidingwindow/sliding_window_test.go
+++ b/collections/slidingwindow/sliding_window_test.go
@@ -1,0 +1,123 @@
+package slidingwindow_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/collections/slidingwindow"
+	"github.com/eluv-io/utc-go"
+)
+
+func TestSlidingWindow(t *testing.T) {
+	clock := utc.NewWallClock(utc.UnixMilli(0))
+	utc.MockNowClock(clock)
+	defer clock.UnmockNow()
+
+	sw := slidingwindow.New[int](5)
+
+	// Add values to the sliding window
+	add := func(v int) {
+		sw.Add(v)
+		clock.Add(time.Second)
+	}
+
+	add(1)
+	add(2)
+	split := clock.Now()
+	add(3)
+	add(4)
+	add(5)
+
+	// Check the mean and count
+	require.Equal(t, 3.0, sw.Mean())
+	require.Equal(t, 5, sw.Count())
+
+	{
+		// validate stats
+		sts := sw.Statistics()
+		require.Equal(t, 3.0, sts.Mean())
+		require.Equal(t, 1, sts.Min())
+		require.Equal(t, 5, sts.Max())
+		require.Equal(t, 0, sts.Quantile(-1.0))
+		require.Equal(t, 0, sts.Quantile(1.1))
+		require.Equal(t, 1, sts.Quantile(0.0))
+		require.Equal(t, 2, sts.Quantile(0.1))
+		require.Equal(t, 2, sts.Quantile(0.25))
+		require.Equal(t, 3, sts.Quantile(0.5))
+		require.Equal(t, 4, sts.Quantile(0.75))
+		require.Equal(t, 5, sts.Quantile(1.0))
+
+		// ensure progressive variance matches full variance
+		require.Equal(t, sts.Variance(), sw.Variance())
+	}
+
+	{
+		// validate stats of subset
+		sts := sw.Statistics(split)
+		require.Equal(t, 3, sts.Count())
+		require.Equal(t, 4.0, sts.Mean())
+		require.Equal(t, 3, sts.Min())
+		require.Equal(t, 5, sts.Max())
+		require.Equal(t, 0, sts.Quantile(-1.0))
+		require.Equal(t, 0, sts.Quantile(1.1))
+		require.Equal(t, 3, sts.Quantile(0.0))
+		require.Equal(t, 4, sts.Quantile(0.5))
+		require.Equal(t, 5, sts.Quantile(1.0))
+	}
+
+	// Add another value, which should replace the oldest value (1)
+	add(6)
+	require.Equal(t, sw.Statistics().Variance(), sw.Variance())
+
+	// Check the mean and count again
+	require.Equal(t, 4.0, sw.Mean())
+	require.Equal(t, 5, sw.Count())
+	require.Equal(t, sw.Statistics().Variance(), sw.Variance())
+
+	// Add more values to test circular behavior
+	add(7)
+	add(8)
+
+	// Check the mean after adding more values
+	require.Equal(t, 6.0, sw.Mean())
+	require.Equal(t, sw.Statistics().Variance(), sw.Variance())
+
+	// Fill up with 1-5 again...
+	add(1)
+	add(2)
+	add(3)
+	add(4)
+	add(5)
+
+	// Check the mean and count
+	require.Equal(t, 3.0, sw.Mean())
+	require.Equal(t, 5, sw.Count())
+	require.InDelta(t, sw.Statistics().Variance(), sw.Variance(), 0.0001, "Variance should match the full variance calculation")
+}
+
+func ExampleSlidingWindow() {
+	sw := slidingwindow.New[float64](3)
+	sw.Add(10)
+	sw.Add(20)
+	sw.Add(30)
+	sw.Add(40) // slides window, now contains 20, 30, 40
+
+	stats := sw.Statistics()
+	fmt.Printf("Count:    %d\n", stats.Count())
+	fmt.Printf("Mean:     %.1f\n", stats.Mean())
+	fmt.Printf("Variance: %.1f\n", stats.Variance())
+	fmt.Printf("Min:      %.1f\n", stats.Min())
+	fmt.Printf("Max:      %.1f\n", stats.Max())
+	fmt.Printf("Median:   %.1f\n", stats.Quantile(0.5))
+
+	// Output:
+	// Count:    3
+	// Mean:     30.0
+	// Variance: 100.0
+	// Min:      20.0
+	// Max:      40.0
+	// Median:   30.0
+}

--- a/collections/slidingwindow/sliding_window_test.go
+++ b/collections/slidingwindow/sliding_window_test.go
@@ -2,6 +2,7 @@ package slidingwindow_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -17,6 +18,21 @@ func TestSlidingWindow(t *testing.T) {
 	defer clock.UnmockNow()
 
 	sw := slidingwindow.New[int](5)
+
+	{
+		// validate stats
+		sts := sw.Statistics()
+		require.Equal(t, 0.0, sts.Mean())
+		require.Equal(t, 0.0, sts.Variance())
+		require.Equal(t, 0.0, sts.Stddev())
+		require.Equal(t, 0, sts.Min())
+		require.Equal(t, 0, sts.Max())
+		require.Equal(t, 0, sts.Quantile(-1.0))
+		require.Equal(t, 0, sts.Quantile(1.1))
+		require.Equal(t, 0, sts.Quantile(0.0))
+		require.Equal(t, 0, sts.Quantile(0.5))
+		require.Equal(t, 0, sts.Quantile(1.0))
+	}
 
 	// Add values to the sliding window
 	add := func(v int) {
@@ -39,6 +55,8 @@ func TestSlidingWindow(t *testing.T) {
 		// validate stats
 		sts := sw.Statistics()
 		require.Equal(t, 3.0, sts.Mean())
+		require.Equal(t, 2.0, sts.Variance())
+		require.Equal(t, math.Sqrt(2.0), sts.Stddev())
 		require.Equal(t, 1, sts.Min())
 		require.Equal(t, 5, sts.Max())
 		require.Equal(t, 0, sts.Quantile(-1.0))
@@ -66,6 +84,19 @@ func TestSlidingWindow(t *testing.T) {
 		require.Equal(t, 3, sts.Quantile(0.0))
 		require.Equal(t, 4, sts.Quantile(0.5))
 		require.Equal(t, 5, sts.Quantile(1.0))
+	}
+
+	{
+		// validate stats of empty subset
+		sts := sw.Statistics(clock.Now())
+		require.Equal(t, 0, sts.Count())
+		require.Equal(t, 0.0, sts.Mean())
+		require.Equal(t, 0.0, sts.Variance())
+		require.Equal(t, 0.0, sts.Stddev())
+		require.Equal(t, 0, sts.Min())
+		require.Equal(t, 0, sts.Max())
+		require.Equal(t, 0, sts.Quantile(0.5))
+		require.Equal(t, 0, sts.Quantile(1.0))
 	}
 
 	// Add another value, which should replace the oldest value (1)
@@ -98,26 +129,67 @@ func TestSlidingWindow(t *testing.T) {
 	require.InDelta(t, sw.Statistics().Variance(), sw.Variance(), 0.0001, "Variance should match the full variance calculation")
 }
 
+func TestSlidingWindow_Variance(t *testing.T) {
+	sw := slidingwindow.New[time.Duration](3)
+	require.Zero(t, sw.Variance())
+	require.Zero(t, sw.Statistics().Variance())
+
+	sw.UseSampleVariance()
+	require.Zero(t, sw.Variance())
+	require.Zero(t, sw.Statistics().Variance())
+
+	sw.Add(2)
+
+	sw.UsePopulationVariance()
+	require.Zero(t, sw.Variance())
+	require.Zero(t, sw.Statistics().Variance())
+
+	sw.UseSampleVariance()
+	require.Zero(t, sw.Variance())
+	require.Zero(t, sw.Statistics().Variance())
+
+	sw.Add(4)
+	sw.Add(6)
+
+	sw.UsePopulationVariance()
+	require.Equal(t, 4.0, sw.Mean())
+	require.Equal(t, 8.0/3.0, sw.Variance())
+	require.Equal(t, 8.0/3.0, sw.Statistics().Variance())
+
+	sw.UseSampleVariance()
+	require.Equal(t, 4.0, sw.Variance())
+	require.Equal(t, 4.0, sw.Statistics().Variance())
+}
+
 func ExampleSlidingWindow() {
-	sw := slidingwindow.New[float64](3)
+	sw := slidingwindow.New[float64](5)
 	sw.Add(10)
 	sw.Add(20)
 	sw.Add(30)
-	sw.Add(40) // slides window, now contains 20, 30, 40
+	sw.Add(40)
+	sw.Add(50)
+	sw.Add(60) // slides window, now contains 20, 30, 40, 50, 60
 
 	stats := sw.Statistics()
 	fmt.Printf("Count:    %d\n", stats.Count())
 	fmt.Printf("Mean:     %.1f\n", stats.Mean())
-	fmt.Printf("Variance: %.1f\n", stats.Variance())
+	fmt.Printf("Variance: %.1f (population)\n", stats.Variance())
 	fmt.Printf("Min:      %.1f\n", stats.Min())
 	fmt.Printf("Max:      %.1f\n", stats.Max())
 	fmt.Printf("Median:   %.1f\n", stats.Quantile(0.5))
+	fmt.Println()
+
+	stats = sw.UseSampleVariance().Statistics()
+	fmt.Printf("Variance: %.1f (sample)\n", stats.Variance())
 
 	// Output:
-	// Count:    3
-	// Mean:     30.0
-	// Variance: 100.0
+	//
+	// Count:    5
+	// Mean:     40.0
+	// Variance: 200.0 (population)
 	// Min:      20.0
-	// Max:      40.0
-	// Median:   30.0
+	// Max:      60.0
+	// Median:   40.0
+	//
+	// Variance: 250.0 (sample)
 }

--- a/util/lru/ref_cache.go
+++ b/util/lru/ref_cache.go
@@ -192,7 +192,9 @@ func (c *RefCache) Release(key string) (evicted bool) {
 	ent, found := c.active[key]
 	if !found {
 		// a cache usage error
-		log.Warn("RefCache: release called for unknown resource!", "key", key)
+		log.Warn("RefCache: release called for unknown resource!",
+			"key", key,
+			"stack", errors.E("RefCache.Release", errors.K.Warn))
 		return
 	}
 
@@ -200,7 +202,9 @@ func (c *RefCache) Release(key string) (evicted bool) {
 	if err != nil {
 		// the entry is in the process of being created... that's similar to the
 		// error above
-		log.Warn("RefCache: release called for resource under construction!", "key", key)
+		log.Warn("RefCache: release called for resource under construction!",
+			"key", key,
+			"stack", errors.E("RefCache.Release", errors.K.Warn))
 		return
 	}
 
@@ -213,7 +217,10 @@ func (c *RefCache) Release(key string) (evicted bool) {
 
 	if ent.refCount < 0 {
 		// that should never happen and would indicate a bug in the cache implementation
-		log.Error("RefCache: reference count negative!", "key", key, "ref_count", ent.refCount)
+		log.Error("RefCache: reference count negative!",
+			"key", key,
+			"ref_count", ent.refCount,
+			"stack", errors.E("RefCache.Release", errors.K.Warn))
 		ent.refCount = 0
 	}
 

--- a/util/lru/ref_cache.go
+++ b/util/lru/ref_cache.go
@@ -194,7 +194,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 		// a cache usage error
 		log.Warn("RefCache: release called for unknown resource!",
 			"key", key,
-			"stack", errors.E("RefCache.Release", errors.K.Warn))
+			"stack", errors.E("RefCache.Release"))
 		return
 	}
 
@@ -204,7 +204,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 		// error above
 		log.Warn("RefCache: release called for resource under construction!",
 			"key", key,
-			"stack", errors.E("RefCache.Release", errors.K.Warn))
+			"stack", errors.E("RefCache.Release"))
 		return
 	}
 
@@ -220,7 +220,7 @@ func (c *RefCache) Release(key string) (evicted bool) {
 		log.Error("RefCache: reference count negative!",
 			"key", key,
 			"ref_count", ent.refCount,
-			"stack", errors.E("RefCache.Release", errors.K.Warn))
+			"stack", errors.E("RefCache.Release"))
 		ent.refCount = 0
 	}
 


### PR DESCRIPTION
This pull request adds a new `SlidingWindow` data structure for managing a fixed-capacity sliding window of numeric values along with statistical computations, adds unit tests for its functionality, and enhances logging in the `RefCache` implementation to include stack traces for better debugging.
