### PR TITLE
add InitLogTracing & TraceLocker to traceutil, fix bugs in ctxutil

### DIFF
--- a/util/ctxutil/stack_test.go
+++ b/util/ctxutil/stack_test.go
@@ -120,6 +120,21 @@ func TestContextStackReleaseReordering(t *testing.T) {
 
 }
 
+func TestContextStackSpanWrapping(t *testing.T) {
+	rootSpan := traceutil.InitTracing("test-span", false)
+
+	span := traceutil.Span()
+	require.Equal(t, rootSpan, span) // this would fail with previous version of contextStack.InitTracing()
+
+	sub := traceutil.StartSpan("sub-span")
+	require.Equal(t, sub, traceutil.Span()) // this would fail with previous version of contextStack.StartSpan()
+	sub.End()
+
+	span.End()
+
+	require.Equal(t, trace.NoopSpan{}, traceutil.Span())
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type anObject struct {

--- a/util/traceutil/tracelocker.go
+++ b/util/traceutil/tracelocker.go
@@ -1,0 +1,66 @@
+package traceutil
+
+import (
+	"sync"
+
+	"github.com/eluv-io/common-go/util/traceutil/trace"
+)
+
+// TraceLocker is a sync.Locker that tracks lock/unlock events in a trace span. It is useful to trace lock contention
+// and duration of critical sections. Tracing must be enabled on the current goroutine for it to have any effect (see
+// traceutil.InitTracing).
+//
+// The generated span starts when Lock() is called and ends when Unlock() is called. In addition, it adds an event
+// "locked" right after the lock is successfully acquired.
+//
+//	{
+//	  "name": "example-lock",
+//	  "time": "5ms",
+//	  "evnt": [
+//	    {
+//	      "name": "locked",
+//	      "at": "3ms"
+//	    }
+//	  ]
+//	}
+type TraceLocker struct {
+	mu   sync.Mutex
+	name string
+	span trace.Span
+}
+
+// NewTraceLocker creates a new TraceLocker with the given name.
+func NewTraceLocker(name string) *TraceLocker {
+	return &TraceLocker{
+		name: name,
+	}
+}
+
+// Lock locks the mutex and starts a new trace span. Ensure that the mutex is unlocked by calling Unlock on the same
+// goroutine.
+func (t *TraceLocker) Lock() {
+	span := StartSpan(t.name)
+	t.mu.Lock()
+	span.Event("locked", nil)
+}
+
+// Unlock unlocks the mutex and ends the trace span. Ensure that the mutex was locked by calling Lock on the same
+// goroutine.
+func (t *TraceLocker) Unlock() {
+	t.mu.Unlock()
+	Span().End()
+}
+
+// LockUnlock is a convenience method that locks the mutex and returns a function that unlocks it. This is useful for
+// deferring the unlock right after locking:
+//
+//	defer NewTraceLocker("update").LockUnlock()()
+func (t *TraceLocker) LockUnlock() (unlock func()) {
+	span := StartSpan(t.name)
+	t.mu.Lock()
+	span.Event("locked", nil)
+	return func() {
+		t.mu.Unlock()
+		span.End()
+	}
+}

--- a/util/traceutil/tracelocker.go
+++ b/util/traceutil/tracelocker.go
@@ -2,14 +2,17 @@ package traceutil
 
 import (
 	"sync"
+
+	"github.com/eluv-io/common-go/util/stackutil"
+	"github.com/eluv-io/errors-go"
 )
 
 // TraceLocker is a sync.Locker that tracks lock/unlock events in a trace span. It is useful to trace lock contention
 // and duration of critical sections. Tracing must be enabled on the current goroutine for it to have any effect (see
 // traceutil.InitTracing).
 //
-// The generated span starts when Lock() is called and ends when Unlock() is called. In addition, it adds an event
-// "locked" right after the lock is successfully acquired.
+// The generated span starts when Lock() is called and ends - by default - when Unlock() is called. In addition, it adds
+// an event "locked" right after the lock is successfully acquired.
 //
 //	{
 //	  "name": "example-lock",
@@ -21,31 +24,86 @@ import (
 //	    }
 //	  ]
 //	}
+//
+// In this default mode, Lock() and Unlock() must be called from the same goroutine - otherwise the trace spans may get
+// corrupted.
+//
+// If WithSpanUnlock(false) is called on construction, the span will end right after acquiring the lock instead. In this
+// mode, the duration of the critical section is not tracked, but Unlock() may be called safely from a different
+// goroutine.
 type TraceLocker struct {
-	mu   sync.Mutex
-	name string
+	mu                 sync.Mutex
+	name               string
+	logCaller          bool
+	logCallerFullstack bool
+	spanUnlock         bool
 }
 
-// NewTraceLocker creates a new TraceLocker with the given name.
-func NewTraceLocker(name string) *TraceLocker {
-	return &TraceLocker{
-		name: name,
+// TraceLockerBuilder is a builder for TraceLocker.
+type TraceLockerBuilder struct {
+	tl *TraceLocker
+}
+
+// WithCaller controls whether the locker will log the caller's call location.
+func (t *TraceLockerBuilder) WithCaller(b bool) *TraceLockerBuilder {
+	t.tl.logCaller = b
+	return t
+}
+
+// WithFullstack controls whether the locker will log the caller's full call stack.
+func (t *TraceLockerBuilder) WithFullstack(b bool) *TraceLockerBuilder {
+	t.tl.logCallerFullstack = b
+	return t
+}
+
+// WithSpanUnlock controls whether the locker will end the span when unlocking (true) or right after acquiring the lock
+// (false).
+func (t *TraceLockerBuilder) WithSpanUnlock(b bool) *TraceLockerBuilder {
+	t.tl.spanUnlock = b
+	return t
+}
+
+func (t *TraceLockerBuilder) Build() *TraceLocker {
+	return t.tl
+}
+
+// BuildTraceLocker returns a builder for a new TraceLocker with the given name. By default, it will log the caller's
+// call location and end the span when unlocking. Call any of the With* methods to change this behavior on construction
+// of the TraceLocker (and never after first use!).
+func BuildTraceLocker(name string) *TraceLockerBuilder {
+	return &TraceLockerBuilder{
+		tl: &TraceLocker{
+			name:               name,
+			logCaller:          true,
+			logCallerFullstack: false,
+			spanUnlock:         true,
+		},
 	}
 }
 
-// Lock locks the mutex and starts a new trace span. Ensure that the mutex is unlocked by calling Unlock on the same
-// goroutine.
+// Lock locks the mutex and starts a new trace span. The caller must ensure that it releases the lock (by calling
+// Unlock) from the same goroutine - otherwise the trace spans may get corrupted.
 func (t *TraceLocker) Lock() {
 	span := StartSpan(t.name)
+	if t.logCallerFullstack {
+		span.Attribute("caller", errors.E("stack"))
+	} else if t.logCaller {
+		span.Attribute("caller", stackutil.Caller(1))
+	}
 	t.mu.Lock()
 	span.Event("locked", nil)
+	if !t.spanUnlock {
+		span.End()
+	}
 }
 
-// Unlock unlocks the mutex and ends the trace span. Ensure that the mutex was locked by calling Lock on the same
-// goroutine.
+// Unlock unlocks the mutex and ends the trace span. The caller must ensure that the mutex was locked (by calling Lock)
+// from the same goroutine - otherwise the trace spans may get corrupted.
 func (t *TraceLocker) Unlock() {
 	t.mu.Unlock()
-	Span().End()
+	if t.spanUnlock {
+		Span().End()
+	}
 }
 
 // LockUnlock is a convenience method that locks the mutex and returns a function that unlocks it. This is useful for

--- a/util/traceutil/tracelocker.go
+++ b/util/traceutil/tracelocker.go
@@ -2,8 +2,6 @@ package traceutil
 
 import (
 	"sync"
-
-	"github.com/eluv-io/common-go/util/traceutil/trace"
 )
 
 // TraceLocker is a sync.Locker that tracks lock/unlock events in a trace span. It is useful to trace lock contention
@@ -26,7 +24,6 @@ import (
 type TraceLocker struct {
 	mu   sync.Mutex
 	name string
-	span trace.Span
 }
 
 // NewTraceLocker creates a new TraceLocker with the given name.

--- a/util/traceutil/tracelocker_test.go
+++ b/util/traceutil/tracelocker_test.go
@@ -51,7 +51,7 @@ func ExampleTraceLocker() {
 	//       "name": "example-lock",
 	//       "time": "5s",
 	//       "attr": {
-	//         "caller": "traceutil.useLocker (tracelocker_test.go:130)"
+	//         "caller": "traceutil.useLocker (tracelocker_test.go:129)"
 	//       },
 	//       "evnt": [
 	//         {
@@ -102,7 +102,7 @@ func ExampleTraceLocker_LockUnlock() {
 	//       "name": "example-lock",
 	//       "time": "5s",
 	//       "attr": {
-	//         "caller": "traceutil.useLocker (tracelocker_test.go:126)"
+	//         "caller": "traceutil.useLocker (tracelocker_test.go:125)"
 	//       },
 	//       "evnt": [
 	//         {

--- a/util/traceutil/tracelocker_test.go
+++ b/util/traceutil/tracelocker_test.go
@@ -1,0 +1,76 @@
+package traceutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/util/jsonutil"
+	"github.com/eluv-io/utc-go"
+)
+
+func TestTraceLocker(t *testing.T) {
+	rootSpan := InitTracing("test", false)
+
+	locker := NewTraceLocker("locktest")
+
+	go func() {
+		// trace here is not recorded, since this goroutine is not initialized for tracing
+		defer locker.LockUnlock()()
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	locker.Lock() // should block for ~50ms
+	locker.Unlock()
+
+	span := rootSpan.FindByName("locktest")
+	require.NotNil(t, span)
+
+	require.NotEmpty(t, span.Events())
+	require.Equal(t, "locked", span.Events()[0].Name)
+	require.InDelta(t, 50*time.Millisecond, span.Duration(), float64(20*time.Millisecond))
+
+	// wg.Wait()
+	rootSpan.End()
+	fmt.Println(rootSpan.Json())
+}
+
+func ExampleTraceLocker() {
+	now := utc.UnixMilli(0)
+	defer utc.MockNowFn(func() utc.UTC { return now })()
+
+	rootSpan := InitTracing("test", false)
+
+	locker := NewTraceLocker("example-lock")
+
+	locker.Lock()
+	now = now.Add(5 * time.Second)
+	locker.Unlock()
+
+	now = now.Add(1 * time.Second)
+	rootSpan.End()
+
+	fmt.Println(jsonutil.MustPretty(rootSpan.Json()))
+
+	// Output:
+	//
+	// {
+	//   "name": "test",
+	//   "time": "6s",
+	//   "subs": [
+	//     {
+	//       "name": "example-lock",
+	//       "time": "5s",
+	//       "evnt": [
+	//         {
+	//           "name": "locked",
+	//           "at": "0s"
+	//         }
+	//       ]
+	//     }
+	//   ]
+	// }
+}

--- a/util/traceutil/tracelog.go
+++ b/util/traceutil/tracelog.go
@@ -1,0 +1,24 @@
+package traceutil
+
+import (
+	"github.com/eluv-io/common-go/util/jsonutil"
+	elog "github.com/eluv-io/log-go"
+)
+
+// InitLogTracing enables tracing for the current goroutine if and only if the given log instance is at the TRACE
+// logging level. Otherwise, does nothing. If enabled, it initializes a root span with the provided name and sets it on
+// the goroutine's context stack using traceutil.InitTracing.
+//
+// The returned function should be called in a defer statement: it will end the root span and log it at TRACE level in
+// the provided log. If tracing is disabled, the returned function is a no-op.
+func InitLogTracing(log *elog.Log, rootSpan string) func() {
+	if !log.IsTrace() {
+		return func() {}
+	}
+	span := InitTracing(rootSpan, false)
+	span.SetMarshalExtended() // enable start/end timestamps in addition to duration
+	return func() {
+		span.End()
+		log.Trace("trace", "span", jsonutil.Stringer(span))
+	}
+}

--- a/util/traceutil/tracelog_test.go
+++ b/util/traceutil/tracelog_test.go
@@ -1,0 +1,67 @@
+package traceutil_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/util/traceutil"
+	elog "github.com/eluv-io/log-go"
+	"github.com/eluv-io/log-go/handlers/text"
+	"github.com/eluv-io/utc-go"
+)
+
+func TestEnableTracing(t *testing.T) {
+	defer utc.MockNow(utc.UnixMilli(0))()
+
+	elog.SetDefault(&elog.Config{
+		Handler: "text",
+		Named: map[string]*elog.Config{
+			"/enabled": {
+				Level: "trace",
+			},
+			"/disabled": {
+				Level: "debug",
+			},
+		},
+	})
+
+	handler, ok := elog.Root().Handler().(*text.Handler)
+	require.True(t, ok, "handler type %T", elog.Root().Handler())
+
+	buf := &bytes.Buffer{}
+	handler.Writer = buf
+
+	enabled := elog.Get("/enabled")
+	disabled := elog.Get("/disabled")
+
+	require.True(t, enabled.IsTrace())
+	require.False(t, disabled.IsTrace())
+
+	doIt := func(log *elog.Log, shouldTrace bool) {
+		defer traceutil.InitLogTracing(log, "test-span")()
+		span := traceutil.StartSpan("test-span-child")
+		defer span.End()
+
+		require.Equal(t, shouldTrace, span.IsRecording())
+
+		log.Info("doing it!", "expect_trace", shouldTrace)
+	}
+
+	doIt(enabled, true)
+	doIt(disabled, false)
+	disabled.SetLevel("trace")
+	doIt(disabled, true)
+
+	expected := `
+1970-01-01T00:00:00.000Z INFO  doing it!                 logger=/enabled expect_trace=true
+1970-01-01T00:00:00.000Z TRACE trace                     logger=/enabled span={"name":"test-span","time":"0s","subs":[{"name":"test-span-child","time":"0s","start":"1970-01-01T00:00:00.000Z","end":"1970-01-01T00:00:00.000Z"}],"start":"1970-01-01T00:00:00.000Z","end":"1970-01-01T00:00:00.000Z"}
+1970-01-01T00:00:00.000Z INFO  doing it!                 logger=/disabled expect_trace=false
+1970-01-01T00:00:00.000Z INFO  doing it!                 logger=/disabled expect_trace=true
+1970-01-01T00:00:00.000Z TRACE trace                     logger=/disabled span={"name":"test-span","time":"0s","subs":[{"name":"test-span-child","time":"0s","start":"1970-01-01T00:00:00.000Z","end":"1970-01-01T00:00:00.000Z"}],"start":"1970-01-01T00:00:00.000Z","end":"1970-01-01T00:00:00.000Z"}
+`
+
+	require.Equal(t, strings.TrimLeft(expected, "\n"), buf.String(), "unexpected log output")
+}


### PR DESCRIPTION
* add `InitLogTracing` to initialize tracing based on a logger's log level
* add `TraceLocker` for mutex tracing: drop-in replacement for `sync.Locker` that generates tracing spans for lock acquisition and release.
* fix bugs in context stack span handling