### PR TITLE
fix lru cache Get for nil values

### DIFF
--- a/util/lru/lru.go
+++ b/util/lru/lru.go
@@ -223,7 +223,7 @@ func (c *TypedCache[K, V]) Get(key K) (V, bool) {
 
 func (c *TypedCache[K, V]) get(key K) (V, bool) {
 	res, found := c.lru.Get(key)
-	if found {
+	if found && res != nil {
 		return res.(V), true
 	}
 	var zero V

--- a/util/lru/lru_test.go
+++ b/util/lru/lru_test.go
@@ -116,6 +116,11 @@ func TestBasic(t *testing.T) {
 	val, ok = lru.Peek(key3)
 	require.True(t, ok)
 	require.Equal(t, val3, val)
+
+	// test nil
+	lru.Add(key3, nil)
+	val, ok = lru.Get(key3)
+	require.Equal(t, nil, val)
 }
 
 func TestGetOrCreateBasic(t *testing.T) {


### PR DESCRIPTION
Fixes the following issue: calling `Get(key)` panics for a non-typed `lru.Cache` if its value was previously set to `nil`, e.g. with `Add(key, nil)`.


```
* /dev/proj-test/sd/sdstore_test.go
  Line 219: - interface conversion: interface is nil, not interface {}
  goroutine 38 [running]:
  	/dev/pkg/mod/github.com/smartystreets/goconvey@v1.8.1/convey/reporting/reports.go:150 +0x3c
  	/dev/pkg/mod/github.com/smartystreets/goconvey@v1.8.1/convey/reporting/reports.go:123 +0x5f
  	/dev/pkg/mod/github.com/smartystreets/goconvey@v1.8.1/convey/context.go:253 +0xba
  panic({0x76a2d60?, 0xc000e40a80?})
  	/dev/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.8.darwin-amd64/src/runtime/panic.go:791 +0x132
  github.com/eluv-io/common-go/util/lru.(*TypedCache[...]).get(0x77345a0?, {0x7676080, 0xc000ea4200?})
  	/dev/pkg/mod/github.com/eluv-io/common-go@v1.1.10/util/lru/lru.go:227 +0x5c
  github.com/eluv-io/common-go/util/lru.(*TypedCache[...]).getOrEvict(0x0, {0x7676080?, 0xc000ea4200}, 0x80, 0x0?, 0x772fd58)
  	/dev/pkg/mod/github.com/eluv-io/common-go@v1.1.10/util/lru/lru.go:536 +0x11b
  github.com/eluv-io/common-go/util/lru.(*TypedCache[...]).getOrCreateBlocking(0x77345a0, {0x7676080, 0xc000ea4200}, 0xc000e2b110, 0x0)
  	/dev/pkg/mod/github.com/eluv-io/common-go@v1.1.10/util/lru/lru.go:297 +0xd2
  github.com/eluv-io/common-go/util/lru.(*TypedCache[...]).GetOrCreate(0x77345a0, {0x7676080, 0xc000ea4200}, 0xc000e2b110, {0x0, 0x0, 0xc000c944e0})
  	/dev/pkg/mod/github.com/eluv-io/common-go@v1.1.10/util/lru/lru.go:276 +0x555
  github.com/proj/sd.(*base).loadParsed(0xc000e0b140, {0x0, 0x0, 0x0})
  	/dev/proj-test/sd/base.go:303 +0xba
  github.com/proj/sd.(*base).load(0x0?, {0x0?, 0x0?, 0x756f32d?})
  	/dev/proj-test/sd/base.go:272 +0xb0
  github.com/proj/sd.(*base).Get(0x0?, {0x0?, 0x77233e0?, 0x0?}, {0x0?, 0x0?, 0x0?})
  	/dev/proj-test/sd/base.go:173 +0x106
  github.com/proj/sd_test.runTests.func1.(*tt).runBasicTests.1.2()
  	/dev/proj-test/sd/sdstore_test.go:219 +0x12a
```