### PR TITLE
fix byteutil.Pool and ioutil.MultiSourceReader

### DIFF
--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -23,7 +23,9 @@ type Counter interface {
 // additional, last element of each buffer. Callers of Pool are expected not to
 // alter this reference counter in any way or to attempt to release a buffer
 // that has been re-sliced. Pool is designed to be a drop-in replacement for
-// sync.Pool, without having to cast interface{} as []byte.
+// sync.Pool, without having to cast interface{} as *[]byte.
+// Note: Pool methods act on *[]byte mainly to avoid unnecessary allocations;
+// see https://github.com/golang/go/blob/9c8bf0e7/src/sync/example_pool_test.go#L17-L19
 type Pool struct {
 	BufSize   int         // Size of buffers
 	p         *sync.Pool  // Backing pool
@@ -44,67 +46,72 @@ func NewPool(bufSize int) *Pool {
 
 // New force creates a new buffer. The reference counter to be set for the
 // buffer defaults to 1.
-func (p *Pool) New() []byte {
+func (p *Pool) New() *[]byte {
 	buf := p.new().(*[]byte)
 	p.setCounter(*buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return *buf
+	return buf
 }
 
 // NewN force creates a new buffer. count specifies the reference counter to be
 // set for the buffer.
-func (p *Pool) NewN(count byte) []byte {
+func (p *Pool) NewN(count byte) *[]byte {
 	buf := p.new().(*[]byte)
 	p.setCounter(*buf, count)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return *buf
+	return buf
 }
 
 // Get retrieves a buffer from the pool; if no previous buffers are available,
 // a new buffer is automatically created. The reference counter to be set for
 // the buffer defaults to 1.
-func (p *Pool) Get() []byte {
+func (p *Pool) Get() *[]byte {
 	buf := p.p.Get().(*[]byte)
 	p.setCounter(*buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return *buf
+	return buf
 }
 
 // GetN retrieves a buffer from the pool; if no previous buffers are available,
 // a new buffer is automatically created. count specifies the reference counter
 // to be set for the buffer.
-func (p *Pool) GetN(count byte) []byte {
+func (p *Pool) GetN(count byte) *[]byte {
 	buf := p.p.Get().(*[]byte)
 	p.setCounter(*buf, count)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return *buf
+	return buf
 }
 
 // Put releases a reference to the given buffer, by decrementing the buffer's
 // reference counter. If the counter reaches 0, the buffer is released back
 // into the pool. The caller should no longer use the buffer after calling.
 // Buffers that have been re-sliced will be ignored.
-func (p *Pool) Put(buf []byte) {
-	if cap(buf) == p.BufSize+1 {
-		buf = buf[:p.BufSize]
-		// Decrement buffer's reference counter
-		if p.decrCounter(buf) {
-			// Release buffer back into pool
-			p.p.Put(&buf)
-			if p.released != nil {
-				p.released.Add(1)
+func (p *Pool) Put(buf *[]byte) {
+	if buf != nil {
+		if cap(*buf) == p.BufSize+1 {
+			if len(*buf) != p.BufSize {
+				b := (*buf)[:p.BufSize]
+				buf = &b // Causes an extra allocation
 			}
+			// Decrement buffer's reference counter
+			if p.decrCounter(*buf) {
+				// Release buffer back into pool
+				p.p.Put(buf)
+				if p.released != nil {
+					p.released.Add(1)
+				}
+			}
+		} else if *buf != nil {
+			log.Debug("buffer not released back into pool", "expected_size", p.BufSize+1, "actual_size", cap(*buf))
 		}
-	} else if buf != nil {
-		log.Debug("buffer not released back into pool", "expected_size", p.BufSize+1, "actual_size", cap(buf))
 	}
 }
 

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -98,6 +98,7 @@ func (p *Pool) Put(buf *[]byte) {
 	if buf != nil {
 		if cap(*buf) == p.BufSize+1 {
 			if len(*buf) != p.BufSize {
+				log.Debug("buffer resized and released back into pool", "expected_size", p.BufSize, "actual_size", len(*buf))
 				b := (*buf)[:p.BufSize]
 				buf = &b // Causes an extra allocation
 			}

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -45,47 +45,47 @@ func NewPool(bufSize int) *Pool {
 // New force creates a new buffer. The reference counter to be set for the
 // buffer defaults to 1.
 func (p *Pool) New() []byte {
-	buf := p.new().([]byte)
-	p.setCounter(buf, 1)
+	buf := p.new().(*[]byte)
+	p.setCounter(*buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return buf
+	return *buf
 }
 
 // NewN force creates a new buffer. count specifies the reference counter to be
 // set for the buffer.
 func (p *Pool) NewN(count byte) []byte {
-	buf := p.new().([]byte)
-	p.setCounter(buf, count)
+	buf := p.new().(*[]byte)
+	p.setCounter(*buf, count)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return buf
+	return *buf
 }
 
 // Get retrieves a buffer from the pool; if no previous buffers are available,
 // a new buffer is automatically created. The reference counter to be set for
 // the buffer defaults to 1.
 func (p *Pool) Get() []byte {
-	buf := p.p.Get().([]byte)
-	p.setCounter(buf, 1)
+	buf := p.p.Get().(*[]byte)
+	p.setCounter(*buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return buf
+	return *buf
 }
 
 // GetN retrieves a buffer from the pool; if no previous buffers are available,
 // a new buffer is automatically created. count specifies the reference counter
 // to be set for the buffer.
 func (p *Pool) GetN(count byte) []byte {
-	buf := p.p.Get().([]byte)
-	p.setCounter(buf, count)
+	buf := p.p.Get().(*[]byte)
+	p.setCounter(*buf, count)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
-	return buf
+	return *buf
 }
 
 // Put releases a reference to the given buffer, by decrementing the buffer's
@@ -98,7 +98,7 @@ func (p *Pool) Put(buf []byte) {
 		// Decrement buffer's reference counter
 		if p.decrCounter(buf) {
 			// Release buffer back into pool
-			p.p.Put(buf)
+			p.p.Put(&buf)
 			if p.released != nil {
 				p.released.Add(1)
 			}
@@ -116,10 +116,11 @@ func (p *Pool) SetMetrics(created, retrieved, released Counter) {
 
 // Creates a byte buffer of configured size.
 func (p *Pool) new() interface{} {
+	buf := make([]byte, p.BufSize+1)[:p.BufSize]
 	if p.created != nil {
 		p.created.Add(1)
 	}
-	return make([]byte, p.BufSize+1)[:p.BufSize]
+	return &buf
 }
 
 // Sets the buffer's reference counter. Only the first count is used, if

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -46,7 +46,7 @@ func NewPool(bufSize int) *Pool {
 // buffer defaults to 1.
 func (p *Pool) New() []byte {
 	buf := p.new().([]byte)
-	p.setCounter(buf, 0)
+	p.setCounter(buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
@@ -54,7 +54,7 @@ func (p *Pool) New() []byte {
 }
 
 // NewN force creates a new buffer. count specifies the reference counter to be
-// set for the buffer; if zero, count defaults to 1.
+// set for the buffer.
 func (p *Pool) NewN(count byte) []byte {
 	buf := p.new().([]byte)
 	p.setCounter(buf, count)
@@ -69,7 +69,7 @@ func (p *Pool) NewN(count byte) []byte {
 // the buffer defaults to 1.
 func (p *Pool) Get() []byte {
 	buf := p.p.Get().([]byte)
-	p.setCounter(buf, 0)
+	p.setCounter(buf, 1)
 	if p.retrieved != nil {
 		p.retrieved.Add(1)
 	}
@@ -78,7 +78,7 @@ func (p *Pool) Get() []byte {
 
 // GetN retrieves a buffer from the pool; if no previous buffers are available,
 // a new buffer is automatically created. count specifies the reference counter
-// to be set for the buffer; if zero, count defaults to 1.
+// to be set for the buffer.
 func (p *Pool) GetN(count byte) []byte {
 	buf := p.p.Get().([]byte)
 	p.setCounter(buf, count)
@@ -125,9 +125,6 @@ func (p *Pool) new() interface{} {
 // Sets the buffer's reference counter. Only the first count is used, if
 // specified. Count is by default 1.
 func (p *Pool) setCounter(buf []byte, count byte) {
-	if count == 0 {
-		count = 1
-	}
 	buf[:p.BufSize+1][p.BufSize] = count
 }
 

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -87,11 +87,6 @@ func (p *Pool) Put(buf []byte) {
 	}
 }
 
-// Close closes the pool. No longer does anything but return nil.
-func (p *Pool) Close() error {
-	return nil
-}
-
 func (p *Pool) SetMetrics(created, retrieved, released Counter) {
 	p.created = created
 	p.retrieved = retrieved

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -95,23 +95,23 @@ func (p *Pool) GetN(count byte) *[]byte {
 // into the pool. The caller should no longer use the buffer after calling.
 // Buffers that have been re-sliced will be ignored.
 func (p *Pool) Put(buf *[]byte) {
-	if buf != nil {
-		if cap(*buf) == p.BufSize+1 {
-			if len(*buf) != p.BufSize {
-				log.Debug("buffer resized and released back into pool", "expected_size", p.BufSize, "actual_size", len(*buf))
-				b := (*buf)[:p.BufSize]
-				buf = &b // Causes an extra allocation
-			}
-			// Decrement buffer's reference counter
-			if p.decrCounter(*buf) {
-				// Release buffer back into pool
-				p.p.Put(buf)
-				if p.released != nil {
-					p.released.Add(1)
-				}
-			}
-		} else if *buf != nil {
-			log.Debug("buffer not released back into pool", "expected_size", p.BufSize+1, "actual_size", cap(*buf))
+	if buf == nil {
+		log.Warn("buffer not released back into pool", "reason", "nil buffer")
+		return
+	} else if cap(*buf) != p.BufSize+1 {
+		log.Warn("buffer not released back into pool", "expected_size", p.BufSize+1, "actual_size", cap(*buf))
+		return
+	} else if len(*buf) != p.BufSize {
+		log.Warn("buffer resized and released back into pool", "expected_size", p.BufSize, "actual_size", len(*buf))
+		b := (*buf)[:p.BufSize]
+		buf = &b // Causes an extra allocation
+	}
+	// Decrement buffer's reference counter
+	if p.decrCounter(*buf) {
+		// Release buffer back into pool
+		p.p.Put(buf)
+		if p.released != nil {
+			p.released.Add(1)
 		}
 	}
 }

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -42,10 +42,20 @@ func NewPool(bufSize int) *Pool {
 	return p
 }
 
-// New force creates a new buffer. Optionally, count specifies the reference
-// counter to be set for the buffer; if ommitted, count defaults to 1. Only the
-// first specified count is used.
-func (p *Pool) New(count ...byte) []byte {
+// New force creates a new buffer. The reference counter to be set for the
+// buffer defaults to 1.
+func (p *Pool) New() []byte {
+	buf := p.new().([]byte)
+	p.setCounter(buf, 0)
+	if p.retrieved != nil {
+		p.retrieved.Add(1)
+	}
+	return buf
+}
+
+// NewN force creates a new buffer. count specifies the reference counter to be
+// set for the buffer; if zero, count defaults to 1.
+func (p *Pool) NewN(count byte) []byte {
 	buf := p.new().([]byte)
 	p.setCounter(buf, count)
 	if p.retrieved != nil {
@@ -55,10 +65,21 @@ func (p *Pool) New(count ...byte) []byte {
 }
 
 // Get retrieves a buffer from the pool; if no previous buffers are available,
-// a new buffer is automatically created. Optionally, count specifies the
-// reference counter to be set for the buffer; if ommitted, count defaults to 1.
-// Only the first specified count is used.
-func (p *Pool) Get(count ...byte) []byte {
+// a new buffer is automatically created. The reference counter to be set for
+// the buffer defaults to 1.
+func (p *Pool) Get() []byte {
+	buf := p.p.Get().([]byte)
+	p.setCounter(buf, 0)
+	if p.retrieved != nil {
+		p.retrieved.Add(1)
+	}
+	return buf
+}
+
+// GetN retrieves a buffer from the pool; if no previous buffers are available,
+// a new buffer is automatically created. count specifies the reference counter
+// to be set for the buffer; if zero, count defaults to 1.
+func (p *Pool) GetN(count byte) []byte {
 	buf := p.p.Get().([]byte)
 	p.setCounter(buf, count)
 	if p.retrieved != nil {
@@ -95,21 +116,19 @@ func (p *Pool) SetMetrics(created, retrieved, released Counter) {
 
 // Creates a byte buffer of configured size.
 func (p *Pool) new() interface{} {
-	buf := make([]byte, p.BufSize+1)[:p.BufSize]
 	if p.created != nil {
 		p.created.Add(1)
 	}
-	return buf
+	return make([]byte, p.BufSize+1)[:p.BufSize]
 }
 
 // Sets the buffer's reference counter. Only the first count is used, if
 // specified. Count is by default 1.
-func (p *Pool) setCounter(buf []byte, count []byte) {
-	n := byte(1)
-	if len(count) > 0 {
-		n = count[0]
+func (p *Pool) setCounter(buf []byte, count byte) {
+	if count == 0 {
+		count = 1
 	}
-	buf[:p.BufSize+1][p.BufSize] = n
+	buf[:p.BufSize+1][p.BufSize] = count
 }
 
 // decrCounter decrements the buffer's reference counter by 1; returns true if

--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -27,7 +27,6 @@ type Counter interface {
 type Pool struct {
 	BufSize   int         // Size of buffers
 	p         *sync.Pool  // Backing pool
-	q         chan []byte // Queue of released buffers
 	created   Counter     // Metric for created buffers
 	retrieved Counter     // Metric for retrieved buffers
 	released  Counter     // Metric for released buffers
@@ -39,23 +38,7 @@ func NewPool(bufSize int) *Pool {
 	p := &Pool{}
 	p.BufSize = bufSize
 	p.p = &sync.Pool{New: p.new}
-	p.q = make(chan []byte)
 	p.locker = util.NoopLocker{}
-
-	// Process buffers to be released sequentially in background
-	go func() {
-		for buf := range p.q {
-			// Decrement buffer's reference counter
-			if p.decrCounter(buf) {
-				// Release buffer back into pool
-				p.p.Put(buf)
-				if p.released != nil {
-					p.released.Add(1)
-				}
-			}
-		}
-	}()
-
 	return p
 }
 
@@ -89,20 +72,23 @@ func (p *Pool) Get(count ...byte) []byte {
 // into the pool. The caller should no longer use the buffer after calling.
 // Buffers that have been re-sliced will be ignored.
 func (p *Pool) Put(buf []byte) {
-	if p.q != nil && cap(buf) == p.BufSize+1 {
-		// Add buffer to queue, to be released sequentially in background
-		p.q <- buf[:p.BufSize]
+	if cap(buf) == p.BufSize+1 {
+		buf = buf[:p.BufSize]
+		// Decrement buffer's reference counter
+		if p.decrCounter(buf) {
+			// Release buffer back into pool
+			p.p.Put(buf)
+			if p.released != nil {
+				p.released.Add(1)
+			}
+		}
 	} else if buf != nil {
 		log.Debug("buffer not released back into pool", "expected_size", p.BufSize+1, "actual_size", cap(buf))
 	}
 }
 
-// Close closes the pool. A closed pool will still service buffers, but buffers
-// will not be re-added to the pool for re-use.
-// Caveat: Close currently must not be executed concurrently with any Put calls
+// Close closes the pool. No longer does anything but return nil.
 func (p *Pool) Close() error {
-	close(p.q)
-	p.q = nil
 	return nil
 }
 

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -164,15 +164,19 @@ func TestPool(t *testing.T) {
 	require.Equal(t, float64(closeCount), ctx.released.val.Load())
 }
 
-// go test -tags "avpipe LLVM byollvm" -count=1 -v -bench=Benchmark* -run=Benchmark ./util/byteutil
+// % go test -count=1 -v -bench="Benchmark*" ./util/byteutil
 // goos: darwin
-// goarch: amd64
+// goarch: arm64
 // pkg: github.com/eluv-io/common-go/util/byteutil
-// BenchmarkPool-8       	  421527	      2413 ns/op	      33 B/op	       1 allocs/op
-// BenchmarkSyncPool-8   	 1000000	      1971 ns/op	      32 B/op	       1 allocs/op
-// BenchmarkNoPool-8     	  156228	      7671 ns/op	   65536 B/op	       1 allocs/op
+// cpu: Apple M4 Max
+// BenchmarkPool
+// BenchmarkPool-16        	 3519895	       340.4 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkSyncPool
+// BenchmarkSyncPool-16    	 3502863	       342.9 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkNoPool
+// BenchmarkNoPool-16      	  658054	      1783 ns/op	   65536 B/op	       1 allocs/op
 // PASS
-// ok  	github.com/eluv-io/common-go/util/byteutil	5.404s
+// ok  	github.com/eluv-io/common-go/util/byteutil	5.471s
 
 func BenchmarkPool(b *testing.B) {
 	p := byteutil.NewPool(bufSize)

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -16,11 +16,11 @@ import (
 
 var bufSize = 64 * 1024
 var data []byte
-var r io.Reader
+var r *bytes.Reader
 
 func init() {
 	data = byteutil.RandomBytes(100 * 1024 * 1024) // 100MB
-	r = bytes.NewBuffer(data)
+	r = bytes.NewReader(data)
 }
 
 type testCtx struct {
@@ -49,7 +49,7 @@ func TestPool(t *testing.T) {
 	createCount++
 	openCount++
 
-	buf = p.New(refCount)
+	buf = p.NewN(refCount)
 	// New (zero-ed) buffer of size 8 with refCount 4 should be created
 	require.Equal(t, bufSize+1, cap(buf))
 	require.Equal(t, bufSize, len(buf))
@@ -67,7 +67,7 @@ func TestPool(t *testing.T) {
 	createCount++
 	openCount++
 
-	buf = p.Get(refCount)
+	buf = p.GetN(refCount)
 	// New (zero-ed) buffer of size 8 with refCount 1 should be created
 	require.Equal(t, bufSize+1, cap(buf))
 	require.Equal(t, bufSize, len(buf))
@@ -127,7 +127,7 @@ func TestPool(t *testing.T) {
 	max := 5000
 	var buf2 []byte
 	for i := 0; i < max; i++ {
-		buf2 = p.Get(0)
+		buf2 = p.Get()
 		openCount++
 		if buf2[0] == 1 {
 			// Existing buffer was re-added to pool and successfully retrieved with new refCount 0
@@ -170,13 +170,15 @@ func TestPool(t *testing.T) {
 // pkg: github.com/eluv-io/common-go/util/byteutil
 // cpu: Apple M4 Max
 // BenchmarkPool
-// BenchmarkPool-16        	 3519895	       340.4 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPool-16        	 3431257	       346.1 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPoolN
+// BenchmarkPoolN-16       	 3473690	       345.8 ns/op	      24 B/op	       1 allocs/op
 // BenchmarkSyncPool
-// BenchmarkSyncPool-16    	 3502863	       342.9 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkSyncPool-16    	 3450381	       349.4 ns/op	      24 B/op	       1 allocs/op
 // BenchmarkNoPool
-// BenchmarkNoPool-16      	  658054	      1783 ns/op	   65536 B/op	       1 allocs/op
+// BenchmarkNoPool-16      	  660004	      1788 ns/op	   65536 B/op	       1 allocs/op
 // PASS
-// ok  	github.com/eluv-io/common-go/util/byteutil	5.471s
+// ok  	github.com/eluv-io/common-go/util/byteutil	7.003s
 
 func BenchmarkPool(b *testing.B) {
 	p := byteutil.NewPool(bufSize)
@@ -186,6 +188,23 @@ func BenchmarkPool(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			buf := p.Get()
+			err := task(b, buf)
+			if err != nil {
+				return
+			}
+			p.Put(buf)
+		}
+	})
+}
+
+func BenchmarkPoolN(b *testing.B) {
+	p := byteutil.NewPool(bufSize)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := p.GetN(1)
 			err := task(b, buf)
 			if err != nil {
 				return
@@ -230,9 +249,10 @@ func BenchmarkNoPool(b *testing.B) {
 
 func task(b *testing.B, buf []byte) error {
 	_, err := r.Read(buf)
-	if err == io.EOF {
-		r = bytes.NewBuffer(data)
-	} else if err != nil {
+	if err == io.EOF || (err == nil && r.Len() < len(buf)) {
+		_, err = r.Seek(io.SeekStart, 0)
+	}
+	if err != nil {
 		b.Error("Unexpected error reading data", err)
 		return err
 	}

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -42,43 +42,43 @@ func TestPool(t *testing.T) {
 
 	buf := p.New()
 	// New (zero-ed) buffer of size 8 with refCount 1 should be created
-	require.Equal(t, bufSize+1, cap(buf))
-	require.Equal(t, bufSize, len(buf))
-	require.Equal(t, zeroBuf, buf)
-	require.Equal(t, byte(1), buf[:bufSize+1][bufSize])
+	require.Equal(t, bufSize+1, cap(*buf))
+	require.Equal(t, bufSize, len(*buf))
+	require.Equal(t, zeroBuf, *buf)
+	require.Equal(t, byte(1), (*buf)[:bufSize+1][bufSize])
 	createCount++
 	openCount++
 
 	buf = p.NewN(refCount)
 	// New (zero-ed) buffer of size 8 with refCount 4 should be created
-	require.Equal(t, bufSize+1, cap(buf))
-	require.Equal(t, bufSize, len(buf))
-	require.Equal(t, zeroBuf, buf)
-	require.Equal(t, refCount, buf[:bufSize+1][bufSize])
+	require.Equal(t, bufSize+1, cap(*buf))
+	require.Equal(t, bufSize, len(*buf))
+	require.Equal(t, zeroBuf, *buf)
+	require.Equal(t, refCount, (*buf)[:bufSize+1][bufSize])
 	createCount++
 	openCount++
 
 	buf = p.Get()
 	// New (zero-ed) buffer of size 8 with refCount 1 should be created
-	require.Equal(t, bufSize+1, cap(buf))
-	require.Equal(t, bufSize, len(buf))
-	require.Equal(t, zeroBuf, buf)
-	require.Equal(t, byte(1), buf[:bufSize+1][bufSize])
+	require.Equal(t, bufSize+1, cap(*buf))
+	require.Equal(t, bufSize, len(*buf))
+	require.Equal(t, zeroBuf, *buf)
+	require.Equal(t, byte(1), (*buf)[:bufSize+1][bufSize])
 	createCount++
 	openCount++
 
 	buf = p.GetN(refCount)
 	// New (zero-ed) buffer of size 8 with refCount 1 should be created
-	require.Equal(t, bufSize+1, cap(buf))
-	require.Equal(t, bufSize, len(buf))
-	require.Equal(t, zeroBuf, buf)
-	require.Equal(t, refCount, buf[:bufSize+1][bufSize])
+	require.Equal(t, bufSize+1, cap(*buf))
+	require.Equal(t, bufSize, len(*buf))
+	require.Equal(t, zeroBuf, *buf)
+	require.Equal(t, refCount, (*buf)[:bufSize+1][bufSize])
 	createCount++
 	openCount++
 
 	// Populate existing buffer with 1s, for identification purposes
-	for i := range buf {
-		buf[i] = 1
+	for i := range *buf {
+		(*buf)[i] = 1
 	}
 
 	mu := &sync.Mutex{}
@@ -98,23 +98,23 @@ func TestPool(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			buf2 := p.Get()
 			openCount++
-			require.Equal(t, make([]byte, bufSize), buf2)
+			require.Equal(t, make([]byte, bufSize), *buf2)
 			createCount++
 			time.Sleep(time.Millisecond)
 		}
 		r1 := ctx.released.val.Load()
 		require.Equal(t, 0.0, r1-r0)
-		require.Equal(t, refCount-n-1, getRefCount(buf))
+		require.Equal(t, refCount-n-1, getRefCount(*buf))
 	}
 
-	require.Equal(t, byte(1), getRefCount(buf))
+	require.Equal(t, byte(1), getRefCount(*buf))
 
 	r0 := ctx.released.val.Load()
 	p.Put(buf)
 	time.Sleep(50 * time.Millisecond)
 	r1 := ctx.released.val.Load()
 	require.Equal(t, 1.0, r1-r0)
-	require.Equal(t, byte(0), getRefCount(buf))
+	require.Equal(t, byte(0), getRefCount(*buf))
 	closeCount++
 
 	// Existing buffer should be re-added to pool
@@ -125,11 +125,11 @@ func TestPool(t *testing.T) {
 	//    Callers should not assume any relation between values passed to Put and
 	//    the values returned by Get.
 	max := 5000
-	var buf2 []byte
+	var buf2 *[]byte
 	for i := 0; i < max; i++ {
 		buf2 = p.GetN(0)
 		openCount++
-		if buf2[0] == 1 {
+		if (*buf2)[0] == 1 {
 			// Existing buffer was re-added to pool and successfully retrieved with new refCount 0
 			fmt.Println(fmt.Sprintf("found buffer at %d", i))
 			break
@@ -140,21 +140,21 @@ func TestPool(t *testing.T) {
 	}
 
 	// make sure we retrieved our buffer
-	if buf2[0] == 1 {
-		require.Equal(t, buf, buf2, "buffer not found")
-		require.Equal(t, byte(0), buf[:bufSize+1][bufSize])
+	if (*buf2)[0] == 1 {
+		require.Equal(t, *buf, *buf2, "buffer not found")
+		require.Equal(t, byte(0), (*buf)[:bufSize+1][bufSize])
 	}
 
 	p.Put(buf2)
 	time.Sleep(50 * time.Millisecond)
-	require.Equal(t, byte(0), getRefCount(buf2))
+	require.Equal(t, byte(0), getRefCount(*buf2))
 
 	// Existing buffer with refCount 0 should not be re-added to pool
 	// Attempt to retrieve existing buffer from pool; buffer should not be found
 	for i := 0; i < 100; i++ {
 		buf3 := p.Get()
 		openCount++
-		require.Equal(t, make([]byte, bufSize), buf3)
+		require.Equal(t, make([]byte, bufSize), *buf3)
 		createCount++
 		time.Sleep(time.Millisecond)
 	}
@@ -170,15 +170,15 @@ func TestPool(t *testing.T) {
 // pkg: github.com/eluv-io/common-go/util/byteutil
 // cpu: Apple M4 Max
 // BenchmarkPool
-// BenchmarkPool-16        	 3504525	       343.5 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPool-16        	 3464422	       345.7 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkPoolN
-// BenchmarkPoolN-16       	 3513205	       341.8 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPoolN-16       	 3478377	       345.8 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkSyncPool
-// BenchmarkSyncPool-16    	 3461325	       348.1 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSyncPool-16    	 3453873	       349.2 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkNoPool
-// BenchmarkNoPool-16      	  661698	      1780 ns/op	   65536 B/op	       1 allocs/op
+// BenchmarkNoPool-16      	  651565	      1772 ns/op	   65536 B/op	       1 allocs/op
 // PASS
-// ok  	github.com/eluv-io/common-go/util/byteutil	7.043s
+// ok  	github.com/eluv-io/common-go/util/byteutil	6.994s
 
 func BenchmarkPool(b *testing.B) {
 	p := byteutil.NewPool(bufSize)
@@ -188,7 +188,7 @@ func BenchmarkPool(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			buf := p.Get()
-			err := task(b, buf)
+			err := task(b, *buf)
 			if err != nil {
 				return
 			}
@@ -205,7 +205,7 @@ func BenchmarkPoolN(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			buf := p.GetN(1)
-			err := task(b, buf)
+			err := task(b, *buf)
 			if err != nil {
 				return
 			}

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -216,15 +216,16 @@ func BenchmarkPoolN(b *testing.B) {
 
 func BenchmarkSyncPool(b *testing.B) {
 	p := &sync.Pool{New: func() interface{} {
-		return make([]byte, bufSize)
+		b := make([]byte, bufSize)
+		return &b
 	}}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			buf := p.Get().([]byte)
-			err := task(b, buf)
+			buf := p.Get().(*[]byte)
+			err := task(b, *buf)
 			if err != nil {
 				return
 			}

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -127,7 +127,7 @@ func TestPool(t *testing.T) {
 	max := 5000
 	var buf2 []byte
 	for i := 0; i < max; i++ {
-		buf2 = p.Get()
+		buf2 = p.GetN(0)
 		openCount++
 		if buf2[0] == 1 {
 			// Existing buffer was re-added to pool and successfully retrieved with new refCount 0

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -170,15 +170,15 @@ func TestPool(t *testing.T) {
 // pkg: github.com/eluv-io/common-go/util/byteutil
 // cpu: Apple M4 Max
 // BenchmarkPool
-// BenchmarkPool-16        	 3431257	       346.1 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPool-16        	 3504525	       343.5 ns/op	      24 B/op	       1 allocs/op
 // BenchmarkPoolN
-// BenchmarkPoolN-16       	 3473690	       345.8 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkPoolN-16       	 3513205	       341.8 ns/op	      24 B/op	       1 allocs/op
 // BenchmarkSyncPool
-// BenchmarkSyncPool-16    	 3450381	       349.4 ns/op	      24 B/op	       1 allocs/op
+// BenchmarkSyncPool-16    	 3461325	       348.1 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkNoPool
-// BenchmarkNoPool-16      	  660004	      1788 ns/op	   65536 B/op	       1 allocs/op
+// BenchmarkNoPool-16      	  661698	      1780 ns/op	   65536 B/op	       1 allocs/op
 // PASS
-// ok  	github.com/eluv-io/common-go/util/byteutil	7.003s
+// ok  	github.com/eluv-io/common-go/util/byteutil	7.043s
 
 func BenchmarkPool(b *testing.B) {
 	p := byteutil.NewPool(bufSize)

--- a/util/ioutil/multi_source_reader.go
+++ b/util/ioutil/multi_source_reader.go
@@ -9,7 +9,8 @@ import (
 	"github.com/eluv-io/errors-go"
 )
 
-var bufPools sync.Map
+var bufPools = make(map[int]*byteutil.Pool)
+var bufPoolsMu = sync.RWMutex{}
 
 var _ io.ReadCloser = (*MultiSourceReader)(nil)
 
@@ -30,10 +31,20 @@ func NewMultiSourceReader(readers []io.ReadCloser, bufferSize ...int) *MultiSour
 	if len(bufferSize) > 0 && bufferSize[0] > 0 {
 		bufSize = bufferSize[0]
 	}
-	bufPool, _ := bufPools.LoadOrStore(bufSize, sync.OnceValue(func() *byteutil.Pool {
-		return byteutil.NewPool(bufSize)
-	}))
-	r.bufPool = bufPool.(func() *byteutil.Pool)()
+
+	var ok bool
+	bufPoolsMu.RLock()
+	r.bufPool, ok = bufPools[bufSize]
+	bufPoolsMu.RUnlock()
+	if !ok {
+		bufPoolsMu.Lock()
+		r.bufPool, ok = bufPools[bufSize] // Double check in case another reader already made the pool just before
+		if !ok {
+			r.bufPool = byteutil.NewPool(bufSize)
+			bufPools[bufSize] = r.bufPool
+		}
+		bufPoolsMu.Unlock()
+	}
 
 	for _, reader := range readers {
 		r.Add(reader)

--- a/util/ioutil/multi_source_reader.go
+++ b/util/ioutil/multi_source_reader.go
@@ -20,18 +20,18 @@ var _ io.ReadCloser = (*MultiSourceReader)(nil)
 // Read will return that error. Each source will be closed immediately once the source is fully read or errors. Close
 // will close any sources that have not yet been closed. If more than one error occurs when reading or closing sources,
 // only the first error encountered will be returned.
-func NewMultiSourceReader(readers []io.ReadCloser, bufSize ...int) *MultiSourceReader {
+func NewMultiSourceReader(readers []io.ReadCloser, bufferSize ...int) *MultiSourceReader {
 	r := &MultiSourceReader{}
 	r.reads = make(chan *multiSourceRead, 32)
 	r.done = make(chan bool)
 	r.errors = &errors.ErrorList{}
 
-	r.bufSize = 1024
-	if len(bufSize) > 0 && bufSize[0] > 0 {
-		r.bufSize = bufSize[0]
+	bufSize := 1024
+	if len(bufferSize) > 0 && bufferSize[0] > 0 {
+		bufSize = bufferSize[0]
 	}
-	bufPool, _ := bufPools.LoadOrStore(r.bufSize, sync.OnceValue(func() *byteutil.Pool {
-		return byteutil.NewPool(r.bufSize + 1)
+	bufPool, _ := bufPools.LoadOrStore(bufSize, sync.OnceValue(func() *byteutil.Pool {
+		return byteutil.NewPool(bufSize)
 	}))
 	r.bufPool = bufPool.(func() *byteutil.Pool)()
 
@@ -52,7 +52,6 @@ type MultiSourceReader struct {
 	err     error
 	errors  *errors.ErrorList
 	closed  bool
-	bufSize int
 	bufPool *byteutil.Pool
 }
 
@@ -216,9 +215,9 @@ func (r *MultiSourceReader) Close() error {
 }
 
 func (r *MultiSourceReader) acquireBuf() []byte {
-	return r.bufPool.Get()[:r.bufSize]
+	return r.bufPool.Get()
 }
 
 func (r *MultiSourceReader) releaseBuf(buf []byte) {
-	r.bufPool.Put(buf[:r.bufSize+1])
+	r.bufPool.Put(buf)
 }

--- a/util/ioutil/multi_source_reader.go
+++ b/util/ioutil/multi_source_reader.go
@@ -70,7 +70,7 @@ type multiSourceRead struct {
 	data []byte
 	off  int64
 	err  error
-	buf  []byte
+	buf  *[]byte
 }
 
 func (r *MultiSourceReader) Add(reader io.ReadCloser) {
@@ -83,12 +83,12 @@ func (r *MultiSourceReader) Add(reader io.ReadCloser) {
 		errored := false
 		for {
 			buf := r.acquireBuf()
-			n, err := reader.Read(buf)
+			n, err := reader.Read(*buf)
 			select {
 			case _ = <-r.done:
 				r.releaseBuf(buf)
 				err = io.ErrUnexpectedEOF // Used only to break from loop
-			case r.reads <- &multiSourceRead{data: buf[:n], off: off, err: err, buf: buf}:
+			case r.reads <- &multiSourceRead{data: (*buf)[:n], off: off, err: err, buf: buf}:
 				off += int64(n)
 				if err != nil {
 					errored = true
@@ -225,10 +225,10 @@ func (r *MultiSourceReader) Close() error {
 	return err
 }
 
-func (r *MultiSourceReader) acquireBuf() []byte {
+func (r *MultiSourceReader) acquireBuf() *[]byte {
 	return r.bufPool.Get()
 }
 
-func (r *MultiSourceReader) releaseBuf(buf []byte) {
+func (r *MultiSourceReader) releaseBuf(buf *[]byte) {
 	r.bufPool.Put(buf)
 }

--- a/util/ioutil/multi_source_reader.go
+++ b/util/ioutil/multi_source_reader.go
@@ -30,8 +30,10 @@ func NewMultiSourceReader(readers []io.ReadCloser, bufSize ...int) *MultiSourceR
 	if len(bufSize) > 0 && bufSize[0] > 0 {
 		r.bufSize = bufSize[0]
 	}
-	bufPool, _ := bufPools.LoadOrStore(r.bufSize, byteutil.NewPool(r.bufSize+1))
-	r.bufPool = bufPool.(*byteutil.Pool)
+	bufPool, _ := bufPools.LoadOrStore(r.bufSize, sync.OnceValue(func() *byteutil.Pool {
+		return byteutil.NewPool(r.bufSize + 1)
+	}))
+	r.bufPool = bufPool.(func() *byteutil.Pool)()
 
 	for _, reader := range readers {
 		r.Add(reader)


### PR DESCRIPTION
Fixes an issue in `ioutil.MultiSourceReader` where originally a new `byteutil.Pool` was created on every `Load()` attempt. The `byteutil.Pool` should only be created once.

Also simplifies `byteutil.Pool` to remove an unnecessary channel and allocations

Original Implementation
```
% go test -count=1 -v -bench="Benchmark*" ./util/byteutil
goos: darwin
goarch: arm64
pkg: github.com/eluv-io/common-go/util/byteutil
cpu: Apple M4 Max
BenchmarkPool
BenchmarkPool-16        	 1254039	       964.0 ns/op	      25 B/op	       1 allocs/op
BenchmarkSyncPool
BenchmarkSyncPool-16    	 3546692	       344.7 ns/op	      24 B/op	       1 allocs/op
BenchmarkNoPool
BenchmarkNoPool-16      	  658483	      1786 ns/op	   65536 B/op	       1 allocs/op
PASS
ok  	github.com/eluv-io/common-go/util/byteutil	6.096s
```
New Implementation
```
% go test -count=1 -v -bench="Benchmark*" ./util/byteutil
goos: darwin
goarch: arm64
pkg: github.com/eluv-io/common-go/util/byteutil
cpu: Apple M4 Max
BenchmarkPool
BenchmarkPool-16        	 3464422	       345.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkPoolN
BenchmarkPoolN-16       	 3478377	       345.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkSyncPool
BenchmarkSyncPool-16    	 3453873	       349.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkNoPool
BenchmarkNoPool-16      	  651565	      1772 ns/op	   65536 B/op	       1 allocs/op
PASS
ok  	github.com/eluv-io/common-go/util/byteutil	6.994s
```