### PR TITLE
fix Token.MarshalText to use value receiver and enhance JSON tests

### DIFF
--- a/format/token/token.go
+++ b/format/token/token.go
@@ -397,7 +397,7 @@ func (t *Token) UnmarshalCBOR(b []byte) error {
 }
 
 // MarshalText implements custom marshaling using the string representation.
-func (t *Token) MarshalText() ([]byte, error) {
+func (t Token) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
 }
 

--- a/format/token/token_test.go
+++ b/format/token/token_test.go
@@ -153,15 +153,19 @@ func TestInvalidStringConversions2(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	b, err := json.Marshal(qwt)
-	assert.NoError(t, err)
-	assert.Equal(t, "\""+expTokenString+"\"", string(b))
+	for _, val := range []any{qwt, *qwt} {
+		t.Run(fmt.Sprintf("%T", val), func(t *testing.T) {
+			b, err := json.Marshal(val)
+			assert.NoError(t, err)
+			assert.Equal(t, "\""+expTokenString+"\"", string(b))
 
-	var unmarshalled token.Token
-	err = json.Unmarshal(b, &unmarshalled)
-	assert.NoError(t, err)
-	assert.True(t, qwt.Equal(&unmarshalled))
-	assert.Equal(t, qwt.String(), unmarshalled.String())
+			var unmarshalled token.Token
+			err = json.Unmarshal(b, &unmarshalled)
+			assert.NoError(t, err)
+			assert.True(t, qwt.Equal(&unmarshalled))
+			assert.Equal(t, qwt.String(), unmarshalled.String())
+		})
+	}
 }
 
 type Wrapper struct {


### PR DESCRIPTION
Changed the `MarshalText` method on `token.Token` from a pointer receiver to a value receiver, ensuring that both `token.Token` values and pointers to `*token.Token` can be marshaled as string. Without this fix, a token.Token value (instead of *token.Token pointer) would marshal as JSON object with the token's individual fields instead of a `txyzABC` string.

This is really a stupid pitfall due to what I would consider a bug in `json.Marshal`... The same holds true for `MarshalJSON`. They fixed this in json/v2:

> In v1, MarshalJSON methods declared on a pointer receiver are only called if the Go value is addressable. In contrast, in v2 a MarshalJSON method is always callable regardless of addressability. The jsonv1.CallMethodsWithLegacySemantics option controls this behavior difference.

See https://github.com/golang/go/issues/71497