### PR TITLE
fix data race found in byteutil/pool

### DIFF
--- a/util/byteutil/pool.go
+++ b/util/byteutil/pool.go
@@ -3,7 +3,6 @@ package byteutil
 import (
 	"sync"
 
-	"github.com/eluv-io/common-go/util"
 	"github.com/eluv-io/log-go"
 )
 
@@ -40,7 +39,7 @@ func NewPool(bufSize int) *Pool {
 	p := &Pool{}
 	p.BufSize = bufSize
 	p.p = &sync.Pool{New: p.new}
-	p.locker = util.NoopLocker{}
+	p.locker = &sync.Mutex{}
 	return p
 }
 
@@ -134,6 +133,8 @@ func (p *Pool) new() interface{} {
 // Sets the buffer's reference counter. Only the first count is used, if
 // specified. Count is by default 1.
 func (p *Pool) setCounter(buf []byte, count byte) {
+	p.locker.Lock()
+	defer p.locker.Unlock()
 	buf[:p.BufSize+1][p.BufSize] = count
 }
 
@@ -145,12 +146,14 @@ func (p *Pool) setCounter(buf []byte, count byte) {
 // 'go:norace' to disable the race detector in unit-tests where we are reading
 // the ref count.
 func (p *Pool) decrCounter(buf []byte) bool {
+	p.locker.Lock()
+	defer p.locker.Unlock()
+
 	buf = buf[:p.BufSize+1]
+
 	n := buf[p.BufSize]
 	if n > 0 {
-		p.locker.Lock()
 		buf[p.BufSize] = n - 1
-		p.locker.Unlock()
 		if n == 1 {
 			return true
 		}

--- a/util/byteutil/pool_test.go
+++ b/util/byteutil/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -162,6 +163,43 @@ func TestPool(t *testing.T) {
 	require.Equal(t, float64(createCount), ctx.created.val.Load())
 	require.Equal(t, float64(openCount), ctx.retrieved.val.Load())
 	require.Equal(t, float64(closeCount), ctx.released.val.Load())
+}
+
+func TestPoolRace(t *testing.T) {
+	bufSize := 8
+	refCount := 2
+
+	ctx := &testCtx{}
+
+	p := byteutil.NewPool(bufSize)
+	p.SetMetrics(&ctx.created, &ctx.retrieved, &ctx.released)
+
+	wg := sync.WaitGroup{}
+	work := func() {
+		defer wg.Done()
+		pbuf := p.GetN(byte(refCount))
+		buf := *pbuf
+		buf[0] = 1
+		locWg := &sync.WaitGroup{}
+		locWg.Add(2)
+		subWork := func() {
+			defer locWg.Done()
+			d := rand.Int31n(100)
+			time.Sleep(time.Millisecond * time.Duration(d))
+			p.Put(pbuf)
+		}
+		for i := 0; i < refCount; i++ {
+			go subWork()
+		}
+		locWg.Wait()
+	}
+
+	count := 10
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go work()
+	}
+	wg.Wait()
 }
 
 // % go test -tags -count=1 -v -bench="Benchmark.*Pool" -run="Benchmark" ./util/byteutil


### PR DESCRIPTION
Issue showing in content-fabric #3910

Relevant benchmarks before (`master` branch) and after (`fix-bytepool-race`branch):

```
     common-go / master
     BenchmarkPool
     BenchmarkPool-8       	  521569	      2671 ns/op	       1 B/op	       0 allocs/op
     BenchmarkPoolN
     BenchmarkPoolN-8      	  400356	      2827 ns/op	       1 B/op	       0 allocs/op

     common-go / fix-bytepool-race
     BenchmarkPool
     BenchmarkPool-8       	  538422	      2831 ns/op	       1 B/op	       0 allocs/op
     BenchmarkPoolN
     BenchmarkPoolN-8      	  431679	      2708 ns/op	       1 B/op	       0 allocs/op
```