### PR TITLE
media/tracker: shared MediaTracker for stream stats, plus allocation-friendly Snapshot/CopyInto

### DIFF
--- a/format/codecs/codecs.go
+++ b/format/codecs/codecs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	cd "github.com/ugorji/go/codec"
 
+	"github.com/eluv-io/common-go/format/duration"
 	"github.com/eluv-io/common-go/format/hash"
 	"github.com/eluv-io/common-go/format/id"
 	"github.com/eluv-io/common-go/format/link"
@@ -160,6 +161,7 @@ func makeCborV2Codec() Codec {
 		{42, reflect.TypeOf((*link.Link)(nil))},
 		{43, reflect.TypeOf((*utc.UTC)(nil))},
 		{44, reflect.TypeOf((*token.Token)(nil))},
+		{45, reflect.TypeOf((*duration.Spec)(nil))},
 	}
 
 	for _, tag := range tags {

--- a/format/codecs/duration_cbor_test.go
+++ b/format/codecs/duration_cbor_test.go
@@ -1,0 +1,66 @@
+package codecs_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/format/duration"
+)
+
+// TestDurationSpecCBORBackwardCompat verifies that a duration.Spec value stored before Spec was tag-registered -
+// a bare, untagged CBOR integer of nanoseconds, since Spec's underlying type is int64 - still decodes correctly now
+// that it is. This encodes through the same MultiCodec (header included), just as a plain int64 rather than a
+// tagged Spec, matching what's already persisted in existing metadata; it must keep decoding as nanoseconds, not be
+// misread as some other unit.
+func TestDurationSpecCBORBackwardCompat(t *testing.T) {
+	buf := &bytes.Buffer{}
+	require.NoError(t, cborCodec.Encoder(buf).Encode(int64(200*time.Millisecond))) // 200,000,000 ns, no tag/marshaler
+
+	var s duration.Spec
+	err := cborCodec.Decoder(bytes.NewReader(buf.Bytes())).Decode(&s)
+	require.NoError(t, err)
+	require.Equal(t, 200*time.Millisecond, s.Duration())
+}
+
+// TestDurationSpecCBORRoundTrip verifies a duration.Spec round-trips through the codec, including inside a generic
+// interface{} decode - the shape used when reading raw metadata (e.g. SQMDR.Get()) - to confirm the decoded value
+// comes back as a duration.Spec, not a bare number. Spec has no custom CBOR marshaling of its own; this relies
+// entirely on Spec's CBOR tag registration (codecs.go) identifying the type on the wire.
+func TestDurationSpecCBORRoundTrip(t *testing.T) {
+	spec := duration.MustParse("200ms")
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, cborCodec.Encoder(buf).Encode(&spec))
+
+	var decoded duration.Spec
+	require.NoError(t, cborCodec.Decoder(bytes.NewReader(buf.Bytes())).Decode(&decoded))
+	require.Equal(t, spec, decoded)
+
+	var generic interface{}
+	require.NoError(t, cborCodec.Decoder(bytes.NewReader(buf.Bytes())).Decode(&generic))
+	genSpec, ok := generic.(duration.Spec)
+	require.True(t, ok, "expected duration.Spec, got %T: %v", generic, generic)
+	require.Equal(t, spec, genSpec)
+}
+
+// TestDurationSpecCBORWrapped verifies the pointer-field shape actually used in production configs
+// (e.g. SrtConnectionConfig.Latency *duration.Spec) round-trips correctly.
+func TestDurationSpecCBORWrapped(t *testing.T) {
+	type wrapper struct {
+		Latency *duration.Spec
+	}
+
+	spec := duration.MustParse("200ms")
+	w := wrapper{Latency: &spec}
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, cborCodec.Encoder(buf).Encode(w))
+
+	var decoded wrapper
+	require.NoError(t, cborCodec.Decoder(bytes.NewReader(buf.Bytes())).Decode(&decoded))
+	require.NotNil(t, decoded.Latency)
+	require.Equal(t, 200*time.Millisecond, decoded.Latency.Duration())
+}

--- a/media/io/stats.go
+++ b/media/io/stats.go
@@ -10,23 +10,23 @@ type ConnStats struct {
 	// RemoteAddr is the remote peer's address ("host:port") - the destination for a sink, or the
 	// connected client for a source. Empty if unavailable (e.g. not yet connected, or a connectionless
 	// UDP source that has no single remote peer).
-	RemoteAddr string
+	RemoteAddr string `json:"remote_addr,omitempty"`
 	// LocalAddr is the local address ("host:port") of the connection - the address a source listens on,
 	// or the local socket of a sink. Empty if unavailable.
-	LocalAddr string
+	LocalAddr string `json:"local_addr,omitempty"`
 	// SRT carries SRT-protocol statistics; nil for non-SRT connections.
-	SRT *SrtConnStats
+	SRT *SrtConnStats `json:"srt,omitempty"`
 }
 
 // SrtConnStats holds the SRT-protocol statistics of a connection.
 type SrtConnStats struct {
 	// Version is the negotiated SRT protocol version of the peer.
-	Version uint32
+	Version uint32 `json:"version"`
 	// Encrypted reports whether the connection is encrypted (a passphrase was configured).
-	Encrypted bool
+	Encrypted bool `json:"encrypted"`
 	// Statistics holds the detailed SRT connection statistics. It is only populated when ConnStats is
 	// called with details=true (gathering it has a cost).
-	Statistics srt.Statistics
+	Statistics srt.Statistics `json:"statistics,omitzero"`
 }
 
 // StatsReporter is implemented by the connection value returned by PacketSink.Open (and

--- a/media/io/stats_test.go
+++ b/media/io/stats_test.go
@@ -1,0 +1,45 @@
+package io
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConnStats_JSONFieldNames locks in snake_case JSON field names for ConnStats/SrtConnStats - both are exported
+// wholesale by callers (e.g. avpipe's ExportedStats.Srt) into dashboard-facing JSON, so a default Go field-name
+// regression here would silently break every consumer's field lookups.
+func TestConnStats_JSONFieldNames(t *testing.T) {
+	stats := ConnStats{
+		RemoteAddr: "1.2.3.4:5678",
+		LocalAddr:  "0.0.0.0:9999",
+		SRT:        &SrtConnStats{Version: 5, Encrypted: true},
+	}
+
+	bb, err := json.Marshal(stats)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(bb, &decoded))
+	require.Equal(t, "1.2.3.4:5678", decoded["remote_addr"])
+	require.Equal(t, "0.0.0.0:9999", decoded["local_addr"])
+
+	srtFields, ok := decoded["srt"].(map[string]any)
+	require.True(t, ok, "decoded JSON must have an \"srt\" object")
+	require.EqualValues(t, 5, srtFields["version"])
+	require.Equal(t, true, srtFields["encrypted"])
+}
+
+// TestConnStats_OmitsEmptyFields verifies RemoteAddr/LocalAddr/SRT are all omitted (not just empty/null) when unset,
+// so a non-SRT or not-yet-connected caller's JSON stays minimal.
+func TestConnStats_OmitsEmptyFields(t *testing.T) {
+	bb, err := json.Marshal(ConnStats{})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(bb, &decoded))
+	require.NotContains(t, decoded, "remote_addr")
+	require.NotContains(t, decoded, "local_addr")
+	require.NotContains(t, decoded, "srt")
+}

--- a/media/mpegts/ts_stream_tracker.go
+++ b/media/mpegts/ts_stream_tracker.go
@@ -34,6 +34,12 @@ type TsStreamTracker interface {
 	TrackPackets(pkts []*packet.Packet) (packetCount int, errList error)
 	// Stats returns TS statistics
 	Stats() *Stats
+	// Snapshot populates snap with the tracker's current stats, reusing snap's Streams slice (and each entry's
+	// JitterMillisHist) where possible instead of allocating new ones - for a caller that polls periodically and
+	// wants to bound per-call garbage. When full is false, it skips the per-PID walk and histogram capture
+	// entirely (the expensive part): Streams is cleared, not populated, and only the cheap running totals
+	// (ErrorCount, PacketCount) are set. Stats() is equivalent to Snapshot(&Stats{}, true).
+	Snapshot(snap *Stats, full bool) *Stats
 	// Reset resets the tracker state, clearing all statistics and errors. It keeps the list of discovered streams and
 	// their information from the PMT (Program Map Table).
 	Reset()
@@ -108,12 +114,16 @@ type tsStreamTracker struct {
 	statsLogFunc func()
 	start        utc.UTC
 	errCount     int
-	streams      map[int]*Stream
-	pmtParsed    bool // true if the PMT has been parsed
-	pmtAcc       packet.Accumulator
-	pat          psi.PAT
-	logThrottle  timeutil.Periodic
-	panics       int
+	// totalCcErrors/totalPacketCount mirror the sum of every stream's ccErrors/packetCount, kept in sync
+	// incrementally in trackPacket so Snapshot(full=false) can report them without walking streams.
+	totalCcErrors    int
+	totalPacketCount int
+	streams          map[int]*Stream
+	pmtParsed        bool // true if the PMT has been parsed
+	pmtAcc           packet.Accumulator
+	pat              psi.PAT
+	logThrottle      timeutil.Periodic
+	panics           int
 }
 
 func (t *tsStreamTracker) Track(bts []byte) (packetCount int, errList error) {
@@ -226,12 +236,14 @@ func (t *tsStreamTracker) trackPacket(pkt *packet.Packet, packetCount int, appen
 		}
 		if cc != expectCC {
 			stream.ccErrors++
+			t.totalCcErrors++
 			err = fmt.Errorf("continuity counter mismatch: expected=%02d actual=%02d ts-packet=%d pid=%d", expectCC, cc, packetCount, pid)
 			appendErr(err)
 		}
 		stream.cc = cc
 	}
 	stream.packetCount++
+	t.totalPacketCount++
 
 	if pcr, ok := ExtractPCR(pkt); ok {
 		now := utc.Now()
@@ -338,46 +350,76 @@ func (t *tsStreamTracker) parsePmt(pkt *packet.Packet) error {
 	return nil
 }
 
+// Stats returns the tracker's current stats as a freshly-allocated Stats. Equivalent to
+// Snapshot(&Stats{}, true).
 func (t *tsStreamTracker) Stats() *Stats {
-	res := &Stats{
-		Start:      t.start,
-		Duration:   duration.Spec(utc.Since(t.start)).RoundTo(2),
-		ErrorCount: t.errCount,
-		Streams:    make([]*StreamStats, 0, len(t.streams)),
+	return t.Snapshot(&Stats{}, true)
+}
+
+// Snapshot populates snap with the tracker's current stats. See the TsStreamTracker interface doc for the
+// full/reuse contract.
+func (t *tsStreamTracker) Snapshot(snap *Stats, full bool) *Stats {
+	snap.Start = t.start
+	snap.Duration = duration.Spec(utc.Since(t.start)).RoundTo(2)
+	snap.ErrorCount = t.errCount
+	snap.CcErrors = t.totalCcErrors
+
+	if !full {
+		snap.Streams = snap.Streams[:0]
+		snap.PacketCount = t.totalPacketCount
+		return snap
 	}
 
 	keys := maputil.SortedKeys(t.streams)
-	for _, pid := range keys {
+	for i, pid := range keys {
 		stream := t.streams[pid]
-		s := &StreamStats{
-			Pid:         pid,
-			PacketCount: stream.packetCount,
-			Cc:          stream.cc,
-			CcErrors:    stream.ccErrors,
-			Pcr:         stream.pcr,
-			Jitter:      duration.Spec(stream.jitter).RoundTo(2),
-		}
-		if stream.pcr0 != utc.Zero {
-			s.Pcr0 = &stream.pcr0
+
+		var s *StreamStats
+		if i < len(snap.Streams) && snap.Streams[i] != nil && snap.Streams[i].Pid == pid {
+			s = snap.Streams[i] // reuse in place - same PID as last time at this position
+		} else {
+			s = &StreamStats{}
+			if i < len(snap.Streams) {
+				snap.Streams[i] = s
+			} else {
+				snap.Streams = append(snap.Streams, s)
+			}
 		}
 
+		s.Pid = pid
+		s.PacketCount = stream.packetCount
+		s.Cc = stream.cc
+		s.CcErrors = stream.ccErrors
+		s.Pcr = stream.pcr
+		s.Jitter = duration.Spec(stream.jitter).RoundTo(2)
+		s.Info = ""
+		if stream.pcr0 != utc.Zero {
+			s.Pcr0 = &stream.pcr0
+		} else {
+			s.Pcr0 = nil
+		}
 		if stream.pes != nil {
 			s.Info = fmt.Sprintf("%d: %s", stream.pes.StreamType(), stream.pes.StreamTypeDescription())
 		}
 		if stream.jitterMillisHist.TotalCount() > 0 {
-			s.JitterMillisHist = &HistogramCapture{}
+			if s.JitterMillisHist == nil {
+				s.JitterMillisHist = &HistogramCapture{}
+			}
 			CaptureHistogram(stream.jitterMillisHist, s.JitterMillisHist)
+		} else {
+			s.JitterMillisHist = nil
 		}
-		res.Streams = append(res.Streams, s)
-
-		res.PacketCount += stream.packetCount
 	}
-	return res
+	snap.Streams = snap.Streams[:len(keys)]
+	snap.PacketCount = t.totalPacketCount
+	return snap
 }
 
 func (t *tsStreamTracker) Reset() {
 	t.start = utc.Now()
 	t.errCount = 0
+	t.totalCcErrors = 0
+	t.totalPacketCount = 0
 	t.pmtParsed = false
 	t.pmtAcc.Reset()
 	for _, stream := range t.streams {
@@ -421,16 +463,23 @@ func (n NoopTracker) Stats() *Stats {
 	return nil
 }
 
+func (n NoopTracker) Snapshot(snap *Stats, full bool) *Stats {
+	return snap
+}
+
 func (n NoopTracker) Reset() {}
 
 // ---------------------------------------------------------------------------------------------------------------------
 
 type Stats struct {
-	Start       utc.UTC        `json:"start"`
-	Duration    duration.Spec  `json:"duration"`
-	PacketCount int            `json:"packet_count"`
-	ErrorCount  int            `json:"error_count"`
-	Streams     []*StreamStats `json:"streams"`
+	Start       utc.UTC       `json:"start"`
+	Duration    duration.Spec `json:"duration"`
+	PacketCount int           `json:"packet_count"`
+	ErrorCount  int           `json:"error_count"`
+	// CcErrors is the sum of every stream's continuity-counter error count - available cheaply (from an
+	// incrementally-maintained running total) even when Streams itself is empty (see Snapshot's full=false case).
+	CcErrors int            `json:"cc_errors"`
+	Streams  []*StreamStats `json:"streams"`
 }
 
 // Categorize returns a packet count per stream type.
@@ -462,6 +511,55 @@ func (s *Stats) Categorize() (stats PacketStats) {
 	stats.PaddingRatio = rat(stats.Padding)
 	stats.OtherRatio = rat(stats.Other)
 	return
+}
+
+// CopyInto deep-copies s into dst, reusing dst's existing Streams slice (and each entry's
+// JitterMillisHist) where their shape already matches, allocating only where it doesn't. Use this to
+// detach a Stats obtained from a caller that may reuse/mutate it later (see TsStreamTracker.Snapshot)
+// into memory the receiver owns outright - unlike a plain struct copy, which would still alias Streams
+// and its nested pointers.
+func (s *Stats) CopyInto(dst *Stats) {
+	dst.Start = s.Start
+	dst.Duration = s.Duration
+	dst.PacketCount = s.PacketCount
+	dst.ErrorCount = s.ErrorCount
+	dst.CcErrors = s.CcErrors
+
+	for i, stream := range s.Streams {
+		var d *StreamStats
+		if i < len(dst.Streams) && dst.Streams[i] != nil {
+			d = dst.Streams[i]
+		} else {
+			d = &StreamStats{}
+			if i < len(dst.Streams) {
+				dst.Streams[i] = d
+			} else {
+				dst.Streams = append(dst.Streams, d)
+			}
+		}
+		d.Pid = stream.Pid
+		d.PacketCount = stream.PacketCount
+		d.Cc = stream.Cc
+		d.CcErrors = stream.CcErrors
+		d.Pcr = stream.Pcr
+		d.Jitter = stream.Jitter
+		d.Info = stream.Info
+		if stream.Pcr0 != nil {
+			pcr0 := *stream.Pcr0
+			d.Pcr0 = &pcr0
+		} else {
+			d.Pcr0 = nil
+		}
+		if stream.JitterMillisHist != nil {
+			if d.JitterMillisHist == nil {
+				d.JitterMillisHist = &HistogramCapture{}
+			}
+			*d.JitterMillisHist = *stream.JitterMillisHist
+		} else {
+			d.JitterMillisHist = nil
+		}
+	}
+	dst.Streams = dst.Streams[:len(s.Streams)]
 }
 
 type PacketStats struct {

--- a/media/mpegts/ts_stream_tracker_snapshot_test.go
+++ b/media/mpegts/ts_stream_tracker_snapshot_test.go
@@ -1,0 +1,133 @@
+package mpegts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTsStreamTracker_Snapshot_ReusesStreamsInPlace verifies that calling Snapshot repeatedly with the same
+// destination reuses each *StreamStats (and its JitterMillisHist) in place rather than reallocating, as long as the
+// PID set and order are stable across calls - the common case for a live stream. The synthetic makeTsBatch fixture
+// doesn't produce continuity-counter-clean packet sequences (see other tests in this package), so Track's error
+// return is intentionally ignored here - only packet counts and *StreamStats identity are under test.
+func TestTsStreamTracker_Snapshot_ReusesStreamsInPlace(t *testing.T) {
+	tr := NewTsStreamTracker("test", 0, false)
+	_, _ = tr.Track(makeTsBatch(100, 1_000_000, 3))
+	_, _ = tr.Track(makeTsBatch(200, 2_000_000, 2))
+
+	snap := &Stats{}
+	tr.Snapshot(snap, true)
+	require.Len(t, snap.Streams, 2)
+	first0, first1 := snap.Streams[0], snap.Streams[1]
+	require.Equal(t, 100, first0.Pid)
+	require.Equal(t, 200, first1.Pid)
+
+	_, _ = tr.Track(makeTsBatch(100, 3_000_000, 3))
+	_, _ = tr.Track(makeTsBatch(200, 4_000_000, 2))
+
+	tr.Snapshot(snap, true)
+	require.Len(t, snap.Streams, 2)
+	require.Same(t, first0, snap.Streams[0], "same PID at the same position reuses the *StreamStats")
+	require.Same(t, first1, snap.Streams[1])
+	require.EqualValues(t, 6, snap.Streams[0].PacketCount, "values are updated in place, not stale")
+	require.EqualValues(t, 4, snap.Streams[1].PacketCount)
+}
+
+// TestTsStreamTracker_Snapshot_NewPidAppears verifies Snapshot handles a PID set that grows between calls (a new
+// elementary stream is discovered mid-capture) without corrupting previously-reused entries.
+func TestTsStreamTracker_Snapshot_NewPidAppears(t *testing.T) {
+	tr := NewTsStreamTracker("test", 0, false)
+	_, _ = tr.Track(makeTsBatch(100, 1_000_000, 3))
+
+	snap := &Stats{}
+	tr.Snapshot(snap, true)
+	require.Len(t, snap.Streams, 1)
+
+	_, _ = tr.Track(makeTsBatch(200, 2_000_000, 5))
+
+	tr.Snapshot(snap, true)
+	require.Len(t, snap.Streams, 2)
+	require.Equal(t, 100, snap.Streams[0].Pid)
+	require.Equal(t, 200, snap.Streams[1].Pid)
+	require.EqualValues(t, 5, snap.Streams[1].PacketCount)
+}
+
+// TestTsStreamTracker_Snapshot_NotFull verifies that full=false skips the per-PID walk (Streams stays empty) while
+// still reporting the cheap running totals (PacketCount from every stream, ErrorCount including CC mismatches).
+func TestTsStreamTracker_Snapshot_NotFull(t *testing.T) {
+	tr := NewTsStreamTracker("test", 0, false)
+	// n=3 packets on one PID: makeTsBatch's packets don't form a continuity-clean sequence, so this alone already
+	// produces CC errors - exactly what this test wants to confirm is visible without the per-PID walk.
+	_, err := tr.Track(makeTsBatch(100, 1_000_000, 3))
+	require.Error(t, err)
+
+	full := &Stats{}
+	tr.Snapshot(full, true)
+
+	lean := &Stats{}
+	tr.Snapshot(lean, false)
+
+	require.Empty(t, lean.Streams, "full=false skips the per-PID walk")
+	require.Equal(t, full.PacketCount, lean.PacketCount, "PacketCount is available cheaply either way")
+	require.Equal(t, full.ErrorCount, lean.ErrorCount, "ErrorCount is available cheaply either way")
+	require.NotZero(t, lean.ErrorCount)
+}
+
+// TestTsStreamTracker_Snapshot_ResetClearsRunningTotals verifies Reset also clears the incrementally-maintained
+// totalCcErrors/totalPacketCount used by Snapshot(full=false), not just the per-stream counters Stats() derives from.
+func TestTsStreamTracker_Snapshot_ResetClearsRunningTotals(t *testing.T) {
+	tr := NewTsStreamTracker("test", 0, false)
+	_, _ = tr.Track(makeTsBatch(100, 1_000_000, 3))
+
+	tr.Reset()
+
+	lean := &Stats{}
+	tr.Snapshot(lean, false)
+	require.Zero(t, lean.PacketCount)
+	require.Zero(t, lean.ErrorCount)
+}
+
+// TestStats_CopyInto verifies CopyInto produces a deeply independent copy - mutating the source after copying must
+// not affect the destination - and reuses the destination's existing Streams/JitterMillisHist where already shaped
+// to match, rather than reallocating.
+func TestStats_CopyInto(t *testing.T) {
+	tr := NewTsStreamTracker("test", 0, false)
+	_, _ = tr.Track(makeTsBatch(100, 1_000_000, 3))
+
+	src := &Stats{}
+	tr.Snapshot(src, true)
+
+	dst := &Stats{}
+	src.CopyInto(dst)
+	require.Len(t, dst.Streams, 1)
+	require.NotSame(t, src.Streams[0], dst.Streams[0], "CopyInto must not alias the source's *StreamStats")
+	require.Equal(t, src.Streams[0].PacketCount, dst.Streams[0].PacketCount)
+	dstStream0 := dst.Streams[0]
+
+	// Mutate the source (as a live tracker reusing src via Snapshot would) and confirm dst is unaffected.
+	_, _ = tr.Track(makeTsBatch(100, 2_000_000, 4))
+	tr.Snapshot(src, true)
+	require.NotEqual(t, src.Streams[0].PacketCount, dst.Streams[0].PacketCount,
+		"dst must not have changed just because src was refreshed")
+
+	// A second CopyInto into the same dst reuses the existing *StreamStats in place.
+	src.CopyInto(dst)
+	require.Same(t, dstStream0, dst.Streams[0], "destination reuse: same *StreamStats, updated in place")
+	require.Equal(t, src.Streams[0].PacketCount, dst.Streams[0].PacketCount)
+}
+
+// TestStats_CopyInto_JitterMillisHist verifies the JitterMillisHist pointer itself is never shared between source
+// and destination, only its values.
+func TestStats_CopyInto_JitterMillisHist(t *testing.T) {
+	src := &Stats{Streams: []*StreamStats{{Pid: 100, JitterMillisHist: &HistogramCapture{Mean: 42}}}}
+	dst := &Stats{}
+
+	src.CopyInto(dst)
+	require.NotNil(t, dst.Streams[0].JitterMillisHist)
+	require.NotSame(t, src.Streams[0].JitterMillisHist, dst.Streams[0].JitterMillisHist)
+	require.Equal(t, 42.0, dst.Streams[0].JitterMillisHist.Mean)
+
+	src.Streams[0].JitterMillisHist.Mean = 99
+	require.Equal(t, 42.0, dst.Streams[0].JitterMillisHist.Mean, "dst's copy is unaffected by mutating src's")
+}

--- a/media/pktpool/packet.go
+++ b/media/pktpool/packet.go
@@ -63,7 +63,10 @@ func NewPacket(wrapCap, cap int) *Packet {
 type Packet struct {
 	Data []byte // the full packet data (a slice of buf): buf[off:off+len]
 
-	// ReceivedAt records when the packet was received, for timestamp tracking. Reset on borrow.
+	// ReceivedAt records when the packet was received, for timestamp tracking. Reset on borrow, and by From/FromReader
+	// as part of loading new data. FromReader re-stamps it itself (as of its Read call), since it performs the read.
+	// From does not read from the network itself, so callers loading a datagram already read elsewhere must set
+	// ReceivedAt explicitly after calling From (see e.g. mpegtsInputHandler.Read in avpipe).
 	ReceivedAt time.Time
 
 	buf        []byte // the internal buffer. Immutable (is never re-assigned to a subslice).
@@ -137,7 +140,7 @@ func (p *Packet) setExtent(length int) {
 	p.decLen = p.len
 }
 
-// FromReader fills the packet from a single Read of the given reader.
+// FromReader fills the packet from a single Read of the given reader and sets its ReceivedAt timestamp.
 //
 // It performs exactly one Read into the buffer's remaining capacity (len(buf)-off) and treats whatever that single
 // Read returns as one complete packet. This makes it suitable only for message-oriented readers that preserve packet
@@ -155,6 +158,7 @@ func (p *Packet) FromReader(reader io.Reader) error {
 	n, err := reader.Read(p.buf[p.off:])
 	if n > 0 {
 		p.setExtent(n)
+		p.ReceivedAt = time.Now()
 	}
 	return err
 }
@@ -164,6 +168,8 @@ func (p *Packet) FromReader(reader io.Reader) error {
 //
 // From is self-contained: it resets the packet's load position and decode state first, so it is safe to reuse a packet
 // (including one previously modified by WrapTlv) without going back through the pool.
+//
+// Note: From does not set the packet's ReceivedAt timestamp - set it outside if needed!
 func (p *Packet) From(bts []byte) error {
 	p.resetForLoad()
 	if len(bts) > len(p.buf)-p.off {

--- a/media/pktpool/packet_test.go
+++ b/media/pktpool/packet_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
@@ -57,12 +58,39 @@ func TestPacket_FromReader_EmptyRead(t *testing.T) {
 
 	require.NoError(t, pkt.T.FromReader(emptyReader{})) // n == 0, err == nil
 	require.Empty(t, pkt.T.Data)
+	require.Zero(t, pkt.T.ReceivedAt) // no data read -> no arrival time to record
 }
 
 // emptyReader is an io.Reader that reads no bytes without erroring (returns 0, nil).
 type emptyReader struct{}
 
 func (emptyReader) Read([]byte) (int, error) { return 0, nil }
+
+// TestPacket_FromReader_StampsReceivedAt verifies that FromReader stamps ReceivedAt itself, as of its own Read call,
+// rather than relying on the caller to do so afterwards. FromReader resets the packet (including ReceivedAt) before
+// reading, so a caller that stamps ReceivedAt before calling FromReader - instead of after - would always observe the
+// zero value; this guards against that ordering mistake regressing (see avpipe's mpegtsInputHandler.ReadPacket, which
+// once had exactly this bug).
+func TestPacket_FromReader_StampsReceivedAt(t *testing.T) {
+	pool := pktpool.NewPacketPool(0, 64)
+	pkt := pool.Borrow()
+	defer pkt.Release()
+
+	require.Zero(t, pkt.T.ReceivedAt) // pristine on borrow
+
+	before := time.Now()
+	require.NoError(t, pkt.T.FromReader(bytes.NewReader(tsPayload(1))))
+	after := time.Now()
+
+	require.False(t, pkt.T.ReceivedAt.IsZero())
+	require.False(t, pkt.T.ReceivedAt.Before(before))
+	require.False(t, pkt.T.ReceivedAt.After(after))
+
+	// A second successful read re-stamps ReceivedAt rather than retaining the first call's value.
+	first := pkt.T.ReceivedAt
+	require.NoError(t, pkt.T.FromReader(bytes.NewReader(tsPayload(1))))
+	require.False(t, pkt.T.ReceivedAt.Before(first))
+}
 
 // TestPacket_LazyDecode_Idempotent verifies that decoding a layer is cached and that repeated access does not corrupt
 // the decode cursor (regression for the missing parsed=true flag).

--- a/media/pktpool/raw_packet.go
+++ b/media/pktpool/raw_packet.go
@@ -1,0 +1,75 @@
+package pktpool
+
+import (
+	"github.com/eluv-io/errors-go"
+)
+
+// Decoder is the lazy, cached, order-enforced RTP/MPEG-TS layer decoding shared by Packet and RawPacket - the two
+// ways to obtain a decoded packet's layers: a pool-managed Packet, or a standalone RawPacket wrapping caller-owned
+// memory. See the Packet type doc for the layer-ordering contract, which applies here unchanged.
+type Decoder interface {
+	Rtp() (*RtpPacket, error)
+	Ts() (*TsPacket, error)
+}
+
+// RawPacket provides Decoder's lazy RTP/MPEG-TS layer decoding directly over a caller-owned byte slice, with no
+// copying, no backing buffer, and no size limit. It is not part of the Pool/Resource machinery - no Init/Reset
+// factory hook, no reference counting - so it must not be shared across goroutines or reused concurrently; it is
+// meant for a single owner reusing one instance across sequential calls (e.g. one MediaTracker instance). Reset
+// re-points the RawPacket at a new slice, discarding previously decoded layers; anything obtained from a previous
+// Reset (Payload slices, decoded headers) is invalidated.
+type RawPacket struct {
+	data     []byte // remaining undecoded data (the lazy-decode cursor)
+	lastRank int
+	rtp      RtpPacket
+	ts       TsPacket
+}
+
+// NewRawPacket creates a RawPacket wrapping data. Equivalent to new(RawPacket) followed by Reset(data).
+func NewRawPacket(data []byte) *RawPacket {
+	return (&RawPacket{}).Reset(data)
+}
+
+// Reset re-points the RawPacket at data, discarding any previously decoded layers. data is aliased, not copied.
+func (p *RawPacket) Reset(data []byte) *RawPacket {
+	p.data = data
+	p.lastRank = -1
+	p.rtp.reset()
+	p.ts.reset()
+	return p
+}
+
+// decodeInOrder mirrors Packet.decodeInOrder (see its doc for the layer-ordering contract), but advances a plain
+// slice cursor instead of a buf/offset pair, since RawPacket has no owning buffer to index into.
+func (p *RawPacket) decodeInOrder(rank int, decode func([]byte) (int, int, error)) error {
+	if rank <= p.lastRank {
+		return errors.NoTrace("pktpool.RawPacket", errors.K.Invalid,
+			"reason", "protocol layer decoded out of order",
+			"rank", rank,
+			"last_rank", p.lastRank)
+	}
+	head, tail, err := decode(p.data)
+	if err != nil {
+		return err
+	}
+	p.data = p.data[head : len(p.data)-tail]
+	p.lastRank = rank
+	return nil
+}
+
+// Rtp returns the RTP packet contained in this RawPacket, parsing it on first access and caching the result.
+func (p *RawPacket) Rtp() (*RtpPacket, error) {
+	if p.rtp.parsed {
+		return &p.rtp, nil
+	}
+	return &p.rtp, p.decodeInOrder(rankRtp, p.rtp.decode)
+}
+
+// Ts returns the MPEG-TS packets contained in the remaining data, parsing them on first access and caching the
+// result.
+func (p *RawPacket) Ts() (*TsPacket, error) {
+	if p.ts.parsed {
+		return &p.ts, nil
+	}
+	return &p.ts, p.decodeInOrder(rankTs, p.ts.decode)
+}

--- a/media/pktpool/raw_packet_test.go
+++ b/media/pktpool/raw_packet_test.go
@@ -33,9 +33,9 @@ func TestRawPacket_LazyDecode(t *testing.T) {
 	}
 }
 
-// TestRawPacket_DecodeOutOfOrder verifies the same layer-ordering guard as Packet: decoding Ts before Rtp on
-// RTP-wrapped data is rejected once bytes have already been consumed by a later-ranked layer... concretely, Rtp then
-// Ts is fine; there is no outer layer to go back to since RawPacket does not expose Tlv.
+// TestRawPacket_DecodeOutOfOrder verifies the same layer-ordering guard as Packet: Rtp then Ts (in rank order) is
+// fine; Ts before Rtp is rejected, since bytes would already have been consumed by the higher-ranked layer with no
+// outer layer to go back to (RawPacket does not expose Tlv).
 func TestRawPacket_DecodeOutOfOrder(t *testing.T) {
 	raw := rtpBytes(t, 1, 0, tsPayload(1))
 	p := pktpool.NewRawPacket(raw)
@@ -44,6 +44,10 @@ func TestRawPacket_DecodeOutOfOrder(t *testing.T) {
 	require.NoError(t, err)
 	_, err = p.Ts()
 	require.NoError(t, err)
+
+	p2 := pktpool.NewRawPacket(rtpBytes(t, 1, 0, tsPayload(1)))
+	_, err = p2.Ts()
+	require.Error(t, err, "Ts before Rtp must be rejected")
 }
 
 // TestRawPacket_Reset verifies that Reset discards previously decoded layers and re-points the cursor at the new

--- a/media/pktpool/raw_packet_test.go
+++ b/media/pktpool/raw_packet_test.go
@@ -1,0 +1,88 @@
+package pktpool_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/media/pktpool"
+)
+
+// TestRawPacket_LazyDecode verifies RawPacket's Rtp/Ts decoding and caching, mirroring
+// TestPacket_LazyDecode_Idempotent but over a plain caller-owned slice instead of a pool-borrowed Packet.
+func TestRawPacket_LazyDecode(t *testing.T) {
+	ts := tsPayload(3)
+	raw := rtpBytes(t, 42, 9000, ts)
+
+	p := pktpool.NewRawPacket(raw)
+	for range 3 { // repeated access must yield identical results
+		r, err := p.Rtp()
+		require.NoError(t, err)
+		require.EqualValues(t, 42, r.Packet().SequenceNumber)
+		require.EqualValues(t, 9000, r.Packet().Timestamp)
+		require.True(t, bytes.Equal(ts, r.Payload))
+	}
+
+	tsPkt, err := p.Ts()
+	require.NoError(t, err)
+	require.Len(t, tsPkt.Packets(), 3)
+	for i, pkt := range tsPkt.Packets() {
+		require.EqualValues(t, 0x47, pkt[0])
+		require.EqualValues(t, i, pkt[1])
+	}
+}
+
+// TestRawPacket_DecodeOutOfOrder verifies the same layer-ordering guard as Packet: decoding Ts before Rtp on
+// RTP-wrapped data is rejected once bytes have already been consumed by a later-ranked layer... concretely, Rtp then
+// Ts is fine; there is no outer layer to go back to since RawPacket does not expose Tlv.
+func TestRawPacket_DecodeOutOfOrder(t *testing.T) {
+	raw := rtpBytes(t, 1, 0, tsPayload(1))
+	p := pktpool.NewRawPacket(raw)
+
+	_, err := p.Rtp()
+	require.NoError(t, err)
+	_, err = p.Ts()
+	require.NoError(t, err)
+}
+
+// TestRawPacket_Reset verifies that Reset discards previously decoded layers and re-points the cursor at the new
+// slice, so a single RawPacket can be reused across sequential calls without reallocating.
+func TestRawPacket_Reset(t *testing.T) {
+	first := rtpBytes(t, 1, 100, tsPayload(1))
+	second := rtpBytes(t, 2, 200, tsPayload(2))
+
+	p := pktpool.NewRawPacket(first)
+	r, err := p.Rtp()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, r.Packet().SequenceNumber)
+
+	p.Reset(second)
+	r, err = p.Rtp()
+	require.NoError(t, err)
+	require.EqualValues(t, 2, r.Packet().SequenceNumber)
+
+	tsPkt, err := p.Ts()
+	require.NoError(t, err)
+	require.Len(t, tsPkt.Packets(), 2)
+}
+
+// TestRawPacket_Unbounded verifies that RawPacket has no size limit (unlike Packet.From, which is bounded by the
+// pool's configured capacity) - the property that motivated RawPacket over a fixed-buffer alternative.
+func TestRawPacket_Unbounded(t *testing.T) {
+	large := rtpBytes(t, 1, 0, tsPayload(1000)) // ~188KB payload
+	p := pktpool.NewRawPacket(large)
+
+	_, err := p.Rtp()
+	require.NoError(t, err)
+	tsLayer, err := p.Ts()
+	require.NoError(t, err)
+	require.Len(t, tsLayer.Packets(), 1000)
+}
+
+// TestRawPacket_SatisfiesDecoder verifies that RawPacket implements the same Decoder interface as Packet, so callers
+// (e.g. common-go/media/tracker.MediaTracker) can accept either uniformly.
+func TestRawPacket_SatisfiesDecoder(t *testing.T) {
+	var _ pktpool.Decoder = pktpool.NewRawPacket(nil)
+	var _ pktpool.Decoder = pktpool.NewPacket(0, 0)
+}

--- a/media/tracker/clock_correlator.go
+++ b/media/tracker/clock_correlator.go
@@ -93,23 +93,26 @@ func (c *clockCorrelator) driftPpm() float64 {
 	return (slope - 1) * 1e6
 }
 
-func (c *clockCorrelator) report(total bool) ClockStats {
+// report writes this correlator's clock stats into dst, so a caller can reuse the same ClockStats across calls
+// instead of allocating a new one each time (see MediaTracker.Snapshot). It only sets the fields common to every
+// clock source (rtp and pcr); the caller-specific fields (Pid, NumWraps, PacketCount, ErrorCount, Gaps,
+// GapsOverflow) are left to rtpCorrelator.report/pcrCorrelator.reports, since which of those apply depends on the
+// concrete correlator, not this base type.
+func (c *clockCorrelator) report(dst *ClockStats, total bool) {
 	skew := &c.skewPeriod
 	if total {
 		skew = &c.skewTotal
 	}
-	return ClockStats{
-		Source:          c.source,
-		Samples:         c.samples,
-		CurrentSkewMs:   c.lastSkew,
-		SkewMinMs:       skew.Min,
-		SkewMeanMs:      skew.Mean,
-		SkewMaxMs:       skew.Max,
-		JitterMs:        duration.Millis(stddev(skew)),
-		DriftPpm:        round(c.driftPpm(), 1),
-		Discontinuities: c.discontinuities,
-		ParseErrors:     c.parseErrors,
-	}
+	dst.Source = c.source
+	dst.Samples = c.samples
+	dst.CurrentSkewMs = c.lastSkew
+	dst.SkewMinMs = skew.Min
+	dst.SkewMeanMs = skew.Mean
+	dst.SkewMaxMs = skew.Max
+	dst.JitterMs = duration.Millis(stddev(skew))
+	dst.DriftPpm = round(c.driftPpm(), 1)
+	dst.Discontinuities = c.discontinuities
+	dst.ParseErrors = c.parseErrors
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -168,13 +171,14 @@ func (c *rtpCorrelator) recordGap(seq, ts int64) {
 	})
 }
 
-func (c *rtpCorrelator) report(total bool) ClockStats {
-	s := c.clockCorrelator.report(total)
-	s.PacketCount = c.packetCount
-	s.ErrorCount = c.errorCount
-	s.Gaps = append([]rtp.Gap(nil), c.gaps...)
-	s.GapsOverflow = c.gapsOverflow
-	return s
+// report writes this correlator's clock stats into dst, reusing dst.Gaps's backing array where capacity allows
+// instead of the defensive copy this used to allocate unconditionally.
+func (c *rtpCorrelator) report(dst *ClockStats, total bool) {
+	c.clockCorrelator.report(dst, total)
+	dst.PacketCount = c.packetCount
+	dst.ErrorCount = c.errorCount
+	dst.Gaps = append(dst.Gaps[:0], c.gaps...)
+	dst.GapsOverflow = c.gapsOverflow
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -230,23 +234,40 @@ func (c *pcrCorrelator) resetPeriod() {
 	}
 }
 
-// reports builds one ClockStats per PCR-bearing PID, in discovery order. Stream-level TS-alignment parse errors are
-// surfaced on the first program's report (they cannot be attributed to a specific program). Before any PCR is seen a
-// single placeholder report is returned so parse errors remain visible.
-func (c *pcrCorrelator) reports(total bool) []ClockStats {
+// reports builds one ClockStats per PCR-bearing PID, in discovery order, appending after whatever dst already holds
+// (e.g. an rtp report at index 0 - see MediaTracker.clockStats) instead of allocating a new slice every call. PIDs
+// are stable for a live stream, so position base+i usually already holds the right PID's ClockStats from the
+// previous call. Stream-level TS-alignment parse errors are surfaced on the first program's report (they cannot be
+// attributed to a specific program). Before any PCR is seen a single placeholder report is returned so parse errors
+// remain visible.
+func (c *pcrCorrelator) reports(dst []ClockStats, total bool) []ClockStats {
+	base := len(dst)
+	n := len(c.pids)
+	if n == 0 {
+		n = 1 // the placeholder entry
+	}
+
+	if cap(dst) < base+n {
+		grown := make([]ClockStats, base+n)
+		copy(grown, dst)
+		dst = grown
+	} else {
+		dst = dst[:base+n]
+	}
+
 	if len(c.pids) == 0 {
-		return []ClockStats{{Source: "pcr", ParseErrors: c.parseErrors}}
+		dst[base] = ClockStats{Source: "pcr", ParseErrors: c.parseErrors}
+		return dst
 	}
-	reports := make([]ClockStats, 0, len(c.pids))
-	for _, pid := range c.pids {
+
+	for i, pid := range c.pids {
 		p := c.byPid[pid]
-		r := p.report(total)
-		r.Pid = p.pid
-		r.NumWraps = p.numWraps
-		reports = append(reports, r)
+		p.report(&dst[base+i], total)
+		dst[base+i].Pid = p.pid
+		dst[base+i].NumWraps = p.numWraps
 	}
-	reports[0].ParseErrors += c.parseErrors
-	return reports
+	dst[base].ParseErrors += c.parseErrors
+	return dst
 }
 
 // record folds a single PCR sample into the PID's correlation statistics. now is the caller-supplied arrival time.

--- a/media/tracker/clock_correlator.go
+++ b/media/tracker/clock_correlator.go
@@ -1,0 +1,267 @@
+package tracker
+
+import (
+	"time"
+
+	"github.com/eluv-io/common-go/format/duration"
+	"github.com/eluv-io/common-go/media/mpegts"
+	"github.com/eluv-io/common-go/media/rtp"
+	"github.com/eluv-io/common-go/util/statsutil"
+	"github.com/eluv-io/utc-go"
+)
+
+// clockCorrelator correlates packet arrival (wall clock) with a single media clock, whose samples are supplied by an
+// enclosing extractor (rtpCorrelator or pcrPidCorrelator). It measures the delivery skew (arrival minus media time),
+// the jitter (variation of that skew) and the long-term clock drift (rate error via linear regression of media on
+// wall time). All arrival timestamps come from the caller (see sample), never from an internal clock read, so the
+// measured skew/jitter reflect the caller's own notion of "arrival time" (e.g. true network-read time even when the
+// caller processes packets from an intermediate queue).
+type clockCorrelator struct {
+	source string                    // "rtp" or "pcr"
+	toWall func(int64) time.Duration // converts unwrapped media ticks to wall-clock duration
+
+	// reference established from the first sample of the current continuous segment
+	hasRef bool
+	wall0  utc.UTC
+	media0 int64 // unwrapped media ticks at the reference
+
+	// linear-regression accumulators over the whole capture (x = wall seconds, y = media seconds)
+	n, sumX, sumY, sumXX, sumXY float64
+
+	samples         uint64
+	discontinuities uint64
+	parseErrors     uint64
+	lastSkew        duration.Millis
+
+	skewTotal  statsutil.Statistics[duration.Millis] // arrival-minus-media skew (whole capture)
+	skewPeriod statsutil.Statistics[duration.Millis] // arrival-minus-media skew (current period)
+}
+
+func newClockCorrelator(source string, toWall func(int64) time.Duration) *clockCorrelator {
+	return &clockCorrelator{source: source, toWall: toWall}
+}
+
+// discontinuity records a media-clock discontinuity (gap) and restarts the reference segment so the next sample
+// re-establishes the arrival-vs-media reference.
+func (c *clockCorrelator) discontinuity() {
+	c.discontinuities++
+	c.hasRef = false
+}
+
+// sample folds a single (arrival, media-ticks) observation into the skew statistics and regression accumulators. now
+// is the caller-supplied arrival time.
+func (c *clockCorrelator) sample(now utc.UTC, ticks int64) {
+	if !c.hasRef {
+		c.hasRef = true
+		c.wall0 = now
+		c.media0 = ticks
+		return
+	}
+	wallDur := now.Sub(c.wall0)
+	mediaDur := c.toWall(ticks - c.media0)
+	skew := duration.Millis(wallDur - mediaDur)
+
+	c.samples++
+	c.lastSkew = skew
+	c.skewTotal.Update(now, skew)
+	c.skewPeriod.Update(now, skew)
+
+	c.n++
+	wall := wallDur.Seconds()
+	media := mediaDur.Seconds()
+	c.sumX += wall
+	c.sumY += media
+	c.sumXX += wall * wall
+	c.sumXY += wall * media
+}
+
+func (c *clockCorrelator) resetPeriod() {
+	c.skewPeriod = statsutil.Statistics[duration.Millis]{}
+}
+
+// driftPpm returns the clock rate error in parts-per-million, estimated as the slope of media time over wall time. A
+// positive value means the media clock runs faster than wall clock (sender clock ahead of receiver).
+func (c *clockCorrelator) driftPpm() float64 {
+	if c.n < 2 {
+		return 0
+	}
+	den := c.n*c.sumXX - c.sumX*c.sumX
+	if den == 0 {
+		return 0
+	}
+	slope := (c.n*c.sumXY - c.sumX*c.sumY) / den
+	return (slope - 1) * 1e6
+}
+
+func (c *clockCorrelator) report(total bool) ClockStats {
+	skew := &c.skewPeriod
+	if total {
+		skew = &c.skewTotal
+	}
+	return ClockStats{
+		Source:          c.source,
+		Samples:         c.samples,
+		CurrentSkewMs:   c.lastSkew,
+		SkewMinMs:       skew.Min,
+		SkewMeanMs:      skew.Mean,
+		SkewMaxMs:       skew.Max,
+		JitterMs:        duration.Millis(stddev(skew)),
+		DriftPpm:        round(c.driftPpm(), 1),
+		Discontinuities: c.discontinuities,
+		ParseErrors:     c.parseErrors,
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// rtpCorrelator extracts the media clock from RTP header timestamps. In addition to the skew/jitter/drift correlation
+// (via the embedded clockCorrelator), it tracks RTP-level packet/error counts and a bounded list of detected gaps -
+// filling the role that avpipe's now-superseded, always-zero SeqNumSkipTot/SeqNumSkipCount fields never actually did.
+type rtpCorrelator struct {
+	*clockCorrelator
+	gap *rtp.GapDetector // RTP sequence/timestamp gap detection and unwrapping
+
+	maxGaps      int
+	packetCount  uint64
+	errorCount   uint64
+	gaps         []rtp.Gap
+	gapsOverflow uint64
+}
+
+func newRtpCorrelator(maxGaps int) *rtpCorrelator {
+	return &rtpCorrelator{
+		clockCorrelator: newClockCorrelator("rtp", rtp.TicksToDuration),
+		gap:             rtp.NewGapDetector(1, time.Second),
+		maxGaps:         maxGaps,
+	}
+}
+
+// record folds a single RTP packet's timestamp into the correlation statistics. now is the caller-supplied arrival
+// time.
+func (c *rtpCorrelator) record(now utc.UTC, seq uint16, ts uint32) {
+	c.packetCount++
+	seqCur, tsCur, err := c.gap.Detect(seq, ts)
+	if err != nil {
+		c.errorCount++
+		c.recordGap(seqCur, tsCur)
+		c.discontinuity()
+		return
+	}
+	c.sample(now, tsCur)
+}
+
+// recordGap appends a Gap event, or - once maxGaps has been reached - only counts it (gapsOverflow), so a long-running
+// stream with sustained gaps cannot grow this list without bound.
+func (c *rtpCorrelator) recordGap(seq, ts int64) {
+	if len(c.gaps) >= c.maxGaps {
+		c.gapsOverflow++
+		return
+	}
+	c.gaps = append(c.gaps, rtp.Gap{
+		PacketNum: int(c.packetCount),
+		Seq:       seq,
+		SeqPrev:   c.gap.Sequence.Previous(),
+		SeqDiff:   seq - c.gap.Sequence.Previous(),
+		Ts:        ts,
+		TsPrev:    c.gap.Timestamp.Previous(),
+		TsDiff:    ts - c.gap.Timestamp.Previous(),
+	})
+}
+
+func (c *rtpCorrelator) report(total bool) ClockStats {
+	s := c.clockCorrelator.report(total)
+	s.PacketCount = c.packetCount
+	s.ErrorCount = c.errorCount
+	s.Gaps = append([]rtp.Gap(nil), c.gaps...)
+	s.GapsOverflow = c.gapsOverflow
+	return s
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// pcrCorrelator correlates arrival with the MPEG-TS PCR of each PCR-bearing PID. A multi-program transport stream
+// carries a separate PCR reference per program, so every PID that carries a PCR is tracked independently, each with
+// its own gap detector and correlation state.
+type pcrCorrelator struct {
+	byPid       map[int]*pcrPidCorrelator
+	pids        []int // PIDs in discovery order, for stable reporting
+	maxGaps     int
+	parseErrors uint64 // TS-alignment errors (stream-level, not attributable to a specific program)
+}
+
+func newPcrCorrelator(maxGaps int) *pcrCorrelator {
+	return &pcrCorrelator{byPid: map[int]*pcrPidCorrelator{}, maxGaps: maxGaps}
+}
+
+// pcrPidCorrelator is the PCR correlator for a single PID.
+type pcrPidCorrelator struct {
+	*clockCorrelator
+	gap mpegts.PcrGapDetector // PCR gap detection and unwrapping
+	pid int
+
+	hasLastRaw bool
+	lastRawPcr uint64
+	numWraps   int64
+}
+
+func newPcrPidCorrelator(pid int) *pcrPidCorrelator {
+	return &pcrPidCorrelator{
+		clockCorrelator: newClockCorrelator("pcr",
+			func(ticks int64) time.Duration { return mpegts.PcrToDuration(uint64(ticks)) }),
+		gap: mpegts.PcrGapDetector{Threshold: mpegts.DurationToPcr(time.Second)},
+		pid: pid,
+	}
+}
+
+// forPid returns the correlator for the given PID, creating it the first time the PID is seen.
+func (c *pcrCorrelator) forPid(pid int) *pcrPidCorrelator {
+	p := c.byPid[pid]
+	if p == nil {
+		p = newPcrPidCorrelator(pid)
+		c.byPid[pid] = p
+		c.pids = append(c.pids, pid)
+	}
+	return p
+}
+
+func (c *pcrCorrelator) resetPeriod() {
+	for _, pid := range c.pids {
+		c.byPid[pid].resetPeriod()
+	}
+}
+
+// reports builds one ClockStats per PCR-bearing PID, in discovery order. Stream-level TS-alignment parse errors are
+// surfaced on the first program's report (they cannot be attributed to a specific program). Before any PCR is seen a
+// single placeholder report is returned so parse errors remain visible.
+func (c *pcrCorrelator) reports(total bool) []ClockStats {
+	if len(c.pids) == 0 {
+		return []ClockStats{{Source: "pcr", ParseErrors: c.parseErrors}}
+	}
+	reports := make([]ClockStats, 0, len(c.pids))
+	for _, pid := range c.pids {
+		p := c.byPid[pid]
+		r := p.report(total)
+		r.Pid = p.pid
+		r.NumWraps = p.numWraps
+		reports = append(reports, r)
+	}
+	reports[0].ParseErrors += c.parseErrors
+	return reports
+}
+
+// record folds a single PCR sample into the PID's correlation statistics. now is the caller-supplied arrival time.
+// It also detects true PCR wraparound (as opposed to reordering/encoder-bug backward jumps), counted in numWraps.
+func (c *pcrPidCorrelator) record(now utc.UTC, pcr uint64) {
+	if c.hasLastRaw && pcr < c.lastRawPcr && c.lastRawPcr-pcr > mpegts.MaxPCR/2 {
+		c.numWraps++
+	}
+	c.hasLastRaw = true
+	c.lastRawPcr = pcr
+
+	_, cur, gap := c.gap.Detect(pcr)
+	if gap {
+		c.discontinuity()
+		return
+	}
+	c.sample(now, cur)
+}

--- a/media/tracker/stats.go
+++ b/media/tracker/stats.go
@@ -110,6 +110,76 @@ type PidErrors struct {
 	CcErrors int `json:"cc_errors"`
 }
 
+// CopyInto deep-copies s into dst, reusing dst's existing slices/pointers (Clocks, each ClockStats.Gaps, Ts,
+// Ts.Streams, Errors.ByPid) where their shape already matches, allocating only where it doesn't. Use this to detach
+// a Stats obtained from a caller that may reuse/mutate it later (see MediaTracker.Snapshot) into memory the
+// receiver owns outright - unlike a plain struct copy, which would still alias every nested slice/pointer.
+func (s *Stats) CopyInto(dst *Stats) {
+	dst.Source = s.Source
+	dst.Elapsed = s.Elapsed
+	dst.Window = s.Window
+	dst.Packets = s.Packets
+	dst.Bytes = s.Bytes
+	dst.Pps = s.Pps
+	dst.Bitrate = s.Bitrate
+	dst.Ipd = s.Ipd
+	dst.Outages = s.Outages
+
+	if s.Rate != nil {
+		if dst.Rate == nil {
+			dst.Rate = &RateStats{}
+		}
+		*dst.Rate = *s.Rate
+	} else {
+		dst.Rate = nil
+	}
+
+	if cap(dst.Clocks) < len(s.Clocks) {
+		dst.Clocks = make([]ClockStats, len(s.Clocks))
+	} else {
+		dst.Clocks = dst.Clocks[:len(s.Clocks)]
+	}
+	for i, c := range s.Clocks {
+		d := &dst.Clocks[i]
+		d.Source = c.Source
+		d.Pid = c.Pid
+		d.Samples = c.Samples
+		d.CurrentSkewMs = c.CurrentSkewMs
+		d.SkewMinMs = c.SkewMinMs
+		d.SkewMeanMs = c.SkewMeanMs
+		d.SkewMaxMs = c.SkewMaxMs
+		d.JitterMs = c.JitterMs
+		d.DriftPpm = c.DriftPpm
+		d.Discontinuities = c.Discontinuities
+		d.ParseErrors = c.ParseErrors
+		d.NumWraps = c.NumWraps
+		d.PacketCount = c.PacketCount
+		d.ErrorCount = c.ErrorCount
+		d.Gaps = append(d.Gaps[:0], c.Gaps...)
+		d.GapsOverflow = c.GapsOverflow
+	}
+
+	dst.Errors.Total = s.Errors.Total
+	dst.Errors.CcErrors = s.Errors.CcErrors
+	dst.Errors.SmallPacketsDropped = s.Errors.SmallPacketsDropped
+	dst.Errors.RtcpPacketsDropped = s.Errors.RtcpPacketsDropped
+	dst.Errors.BadPackets = s.Errors.BadPackets
+	dst.Errors.IncompletePackets = s.Errors.IncompletePackets
+	dst.Errors.AdaptationFieldErrors = s.Errors.AdaptationFieldErrors
+	dst.Errors.FaultyPaddingPackets = s.Errors.FaultyPaddingPackets
+	dst.Errors.LongHeaders = s.Errors.LongHeaders
+	dst.Errors.ByPid = append(dst.Errors.ByPid[:0], s.Errors.ByPid...)
+
+	if s.Ts != nil {
+		if dst.Ts == nil {
+			dst.Ts = &mpegts.Stats{}
+		}
+		s.Ts.CopyInto(dst.Ts)
+	} else {
+		dst.Ts = nil
+	}
+}
+
 // newDistribution builds a Distribution report from the collected statistics and the matching percentile histogram.
 func newDistribution(s *statsutil.Statistics[duration.Millis], h *histogram.Histogram[duration.Millis]) Distribution {
 	return Distribution{

--- a/media/tracker/stats.go
+++ b/media/tracker/stats.go
@@ -1,0 +1,142 @@
+package tracker
+
+import (
+	"fmt"
+
+	"github.com/eluv-io/common-go/format/duration"
+	"github.com/eluv-io/common-go/media/mpegts"
+	"github.com/eluv-io/common-go/media/rtp"
+	"github.com/eluv-io/common-go/util/histogram"
+	"github.com/eluv-io/common-go/util/statsutil"
+)
+
+// Stats is the JSON-serializable snapshot of the stream's timing characteristics for a period or the whole capture.
+type Stats struct {
+	Source  string        `json:"source"`
+	Elapsed duration.Spec `json:"elapsed"`
+	Window  duration.Spec `json:"window,omitempty"` // reporting period (PeriodStats only)
+	Packets uint64        `json:"packets"`
+	Bytes   uint64        `json:"bytes"`
+	Pps     float64       `json:"pps"`         // packets per second
+	Bitrate uint64        `json:"bitrate_bps"` // bits per second
+	Rate    *RateStats    `json:"rate,omitempty"`
+	Ipd     Distribution  `json:"ipd_ms"` // inter-packet delay distribution (milliseconds)
+	Clocks  []ClockStats  `json:"clocks"` // media-clock correlations (RTP timestamp and/or per-program MPEG-TS PCR)
+	Outages OutageStats   `json:"outages"`
+	Errors  ErrorStats    `json:"errors"`       // cumulative validation/integrity errors
+	Ts      *mpegts.Stats `json:"ts,omitempty"` // MPEG-TS program/PID structure and integrity (Stats only)
+}
+
+// Distribution summarizes a set of millisecond measurements: count, extremes, mean, standard deviation and selected
+// percentiles (estimated from a histogram). The millisecond values serialize with 3 digits after the decimal point.
+type Distribution struct {
+	Count  uint64          `json:"count"`
+	Min    duration.Millis `json:"min"`
+	Mean   duration.Millis `json:"mean"`
+	Max    duration.Millis `json:"max"`
+	Stddev duration.Millis `json:"stddev"`
+	P50    duration.Millis `json:"p50"`
+	P90    duration.Millis `json:"p90"`
+	P95    duration.Millis `json:"p95"`
+	P99    duration.Millis `json:"p99"`
+}
+
+// RateStats captures the variation of packet and bit rate across reporting periods (Stats only).
+type RateStats struct {
+	PpsMean   float64 `json:"pps_mean"`
+	PpsStddev float64 `json:"pps_stddev"`
+	PpsMin    float64 `json:"pps_min"`
+	PpsMax    float64 `json:"pps_max"`
+	BpsMean   uint64  `json:"bps_mean"`
+	BpsStddev uint64  `json:"bps_stddev"`
+	BpsMin    uint64  `json:"bps_min"`
+	BpsMax    uint64  `json:"bps_max"`
+}
+
+// ClockStats describes the correlation between packet arrival and one of the stream's media clocks.
+type ClockStats struct {
+	Source          string          `json:"source"` // "rtp" or "pcr"
+	Pid             int             `json:"pid,omitempty"`
+	Samples         uint64          `json:"samples"`
+	CurrentSkewMs   duration.Millis `json:"current_skew_ms"` // most recent arrival-minus-media skew
+	SkewMinMs       duration.Millis `json:"skew_min_ms"`
+	SkewMeanMs      duration.Millis `json:"skew_mean_ms"`
+	SkewMaxMs       duration.Millis `json:"skew_max_ms"`
+	JitterMs        duration.Millis `json:"jitter_ms"` // standard deviation of the skew (packet delay variation)
+	DriftPpm        float64         `json:"drift_ppm"` // media-vs-wall clock rate error
+	Discontinuities uint64          `json:"discontinuities"`
+	ParseErrors     uint64          `json:"parse_errors"`
+
+	// NumWraps is the number of true PCR wraparounds observed on this PID ("pcr" source only).
+	NumWraps int64 `json:"num_wraps,omitempty"`
+
+	// PacketCount, ErrorCount and Gaps describe RTP-level packet health ("rtp" source only). Gaps is bounded by
+	// Config.MaxGaps; GapsOverflow counts any gaps beyond that bound that were not retained.
+	PacketCount  uint64    `json:"packet_count,omitempty"`
+	ErrorCount   uint64    `json:"error_count,omitempty"`
+	Gaps         []rtp.Gap `json:"gaps,omitempty"`
+	GapsOverflow uint64    `json:"gaps_overflow,omitempty"`
+}
+
+// OutageStats counts gaps between consecutive packets exceeding Config.OutageThreshold.
+type OutageStats struct {
+	Count   uint64          `json:"count"`
+	TotalMs duration.Millis `json:"total_ms"`
+}
+
+// ErrorStats summarizes validation and input-integrity errors accumulated over the capture. Total and CcErrors are
+// mpegts.TsStreamTracker's cumulative error count and continuity-counter-error subtotal; ByPid lists the PIDs that
+// have seen continuity errors. The remaining fields cover input-integrity conditions mpegts.TsStreamTracker does not
+// itself detect (malformed/undersized datagrams, RTP framing issues, faulty padding).
+type ErrorStats struct {
+	Total    int         `json:"total"`
+	CcErrors int         `json:"cc_errors"`
+	ByPid    []PidErrors `json:"by_pid,omitempty"`
+
+	SmallPacketsDropped   uint64 `json:"small_packets_dropped"`
+	RtcpPacketsDropped    uint64 `json:"rtcp_packets_dropped"`
+	BadPackets            uint64 `json:"bad_packets"`
+	IncompletePackets     uint64 `json:"incomplete_packets"`
+	AdaptationFieldErrors uint64 `json:"adaptation_field_errors"`
+	FaultyPaddingPackets  uint64 `json:"faulty_padding_packets"`
+	LongHeaders           uint64 `json:"long_headers"`
+}
+
+// PidErrors is the per-PID continuity-counter error count.
+type PidErrors struct {
+	Pid      int `json:"pid"`
+	CcErrors int `json:"cc_errors"`
+}
+
+// newDistribution builds a Distribution report from the collected statistics and the matching percentile histogram.
+func newDistribution(s *statsutil.Statistics[duration.Millis], h *histogram.Histogram[duration.Millis]) Distribution {
+	return Distribution{
+		Count:  s.Count,
+		Min:    s.Min,
+		Mean:   s.Mean,
+		Max:    s.Max,
+		Stddev: duration.Millis(stddev(s)),
+		P50:    h.Quantile(0.50),
+		P90:    h.Quantile(0.90),
+		P95:    h.Quantile(0.95),
+		P99:    h.Quantile(0.99),
+	}
+}
+
+// newIpdHistogram builds a fine-grained millisecond histogram suitable for inter-packet delays, which for a healthy
+// stream are typically only a few milliseconds. Percentiles are estimated from these bins.
+func newIpdHistogram() *histogram.Histogram[duration.Millis] {
+	maxes := []float64{
+		0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 7, 10, 15, 20, 30, 50, 75, 100, 150, 200, 300, 500, 750, 1000, 2000, 5000,
+	}
+	bins := make([]*histogram.HistogramBin[duration.Millis], 0, len(maxes)+1)
+	for _, m := range maxes {
+		bins = append(bins, &histogram.HistogramBin[duration.Millis]{
+			Label: fmt.Sprintf("<=%gms", m),
+			Max:   duration.MillisFromFloat(m),
+		})
+	}
+	bins = append(bins, &histogram.HistogramBin[duration.Millis]{Label: ">5000ms"}) // unbounded final bin
+	h, _ := histogram.NewHistogramBins(bins)
+	return h
+}

--- a/media/tracker/stats.go
+++ b/media/tracker/stats.go
@@ -93,8 +93,10 @@ type ErrorStats struct {
 	CcErrors int         `json:"cc_errors"`
 	ByPid    []PidErrors `json:"by_pid,omitempty"`
 
-	SmallPacketsDropped   uint64 `json:"small_packets_dropped"`
-	RtcpPacketsDropped    uint64 `json:"rtcp_packets_dropped"`
+	SmallPacketsDropped uint64 `json:"small_packets_dropped"`
+	RtcpPacketsDropped  uint64 `json:"rtcp_packets_dropped"`
+	// BadPackets counts RTP-layer failures only (header parse failure or an unsupported RTP version) - it does not
+	// include malformed/misaligned TS packets, which surface via Total/CcErrors instead.
 	BadPackets            uint64 `json:"bad_packets"`
 	IncompletePackets     uint64 `json:"incomplete_packets"`
 	AdaptationFieldErrors uint64 `json:"adaptation_field_errors"`

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -34,6 +34,13 @@ const defaultMaxGaps = 100
 // rtpTsMinLen is the minimum datagram length for RTP-wrapped MPEG-TS: an RTP header plus at least one TS packet.
 const rtpTsMinLen = 12 + packet.PacketSize
 
+// ErrDropped is returned by TrackDatagram/TrackPacket when the datagram was too small to plausibly contain valid
+// media data and was dropped before any parsing was attempted (see ErrorStats.SmallPacketsDropped/RtcpPacketsDropped).
+// A caller that only forwards/writes successfully-tracked datagrams should treat any non-nil return value - including
+// ErrDropped - the same way (skip); a caller that specifically needs to distinguish "dropped outright" from "parsed
+// but found invalid" can compare against this sentinel.
+var ErrDropped = errors.NoTrace("MediaTracker", errors.K.Invalid, "reason", "datagram dropped: too small")
+
 // Config configures a MediaTracker.
 type Config struct {
 	// Rtp selects whether the input is RTP-wrapped MPEG-TS. When true, the RTP timestamp clock is correlated in
@@ -161,7 +168,7 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 			if isRTCP(datagram) {
 				t.rtcpPacketsDropped++
 			}
-			return nil
+			return ErrDropped
 		}
 		pkt, err := rtp.ParsePacket(datagram)
 		if err != nil {
@@ -179,7 +186,7 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 		tsBytes = pkt.Payload
 	} else if len(datagram) < packet.PacketSize {
 		t.smallPacketsDropped++
-		return nil
+		return ErrDropped
 	}
 
 	if len(tsBytes)%packet.PacketSize != 0 {
@@ -211,7 +218,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 			if isRTCP(datagram) {
 				t.rtcpPacketsDropped++
 			}
-			return nil
+			return ErrDropped
 		}
 		rtpLayer, err := pkt.Rtp()
 		if err != nil {
@@ -235,7 +242,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 		t.rtpClock.record(now, hdr.SequenceNumber, hdr.Timestamp)
 	} else if len(datagram) < packet.PacketSize {
 		t.smallPacketsDropped++
-		return nil
+		return ErrDropped
 	}
 
 	tsLayer, err := pkt.Ts()

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -59,6 +59,15 @@ type Config struct {
 	OnPcr func(pid int, pcr uint64)
 }
 
+// SnapshotOptions controls which parts of a Snapshot call are populated, letting a caller skip computing fields it
+// doesn't need.
+type SnapshotOptions struct {
+	// SkipTs, if true, skips mpegts.TsStreamTracker's per-PID walk and histogram capture - the most expensive part
+	// of a snapshot. Stats.Ts is left nil; Errors.Total/CcErrors still populate from cheap running totals, but
+	// Errors.ByPid (which requires the per-PID breakdown) is left empty.
+	SkipTs bool
+}
+
 // MediaTracker tracks the timing and integrity of a live media stream. See the package doc for an overview.
 type MediaTracker interface {
 	// TrackDatagram processes one raw network datagram received at now (the datagram's arrival time), parsing the
@@ -67,10 +76,19 @@ type MediaTracker interface {
 	// TrackPacket processes one already-decoded pooled packet received at now (the packet's arrival time), reusing
 	// its already-parsed RTP/MPEG-TS layers instead of re-parsing pkt.Data.
 	TrackPacket(now utc.UTC, pkt *pktpool.Packet) error
-	// Stats returns the cumulative stats for the whole capture.
+	// Stats returns the cumulative stats for the whole capture. Equivalent to Snapshot(&Stats{}, true, utc.Now(),
+	// SnapshotOptions{}).
 	Stats() *Stats
-	// PeriodStats returns the stats for the current reporting period and resets the period window.
+	// PeriodStats returns the stats for the current reporting period and resets the period window. Equivalent to
+	// Snapshot(&Stats{}, false, utc.Now(), SnapshotOptions{}).
 	PeriodStats() *Stats
+	// Snapshot populates snap with the cumulative (total=true) or current-period (total=false) stats as of now,
+	// reusing snap's existing slices (Clocks, each ClockStats.Gaps, Errors.ByPid) where possible instead of
+	// allocating new ones - for a caller that polls periodically and wants to bound per-call garbage. When
+	// total is false, this also resets the period window, exactly like PeriodStats. snap's nested slices are
+	// invalidated by the next Snapshot/Stats/PeriodStats call that reuses the same snap; do not read them
+	// concurrently with such a call, and see Stats.CopyInto to detach a copy that outlives the next call.
+	Snapshot(snap *Stats, total bool, now utc.UTC, opts SnapshotOptions) *Stats
 	// Reset resets the tracker state, clearing all statistics.
 	Reset()
 }
@@ -140,6 +158,11 @@ type mediaTracker struct {
 	// allocating; it aliases the datagram passed to TrackDatagram only for the duration of that call - never
 	// retained after trackLocked returns.
 	rawPkt *pktpool.RawPacket
+
+	// tsScratch is a reused destination for gathering tsTracker's stats when the result isn't exposed via
+	// Stats.Ts itself (a period snapshot, which never sets Ts - see Snapshot) but is still needed to derive
+	// Errors.Total/CcErrors/ByPid. Lazily allocated on first use.
+	tsScratch *mpegts.Stats
 
 	// counters for input validation/integrity conditions not covered by tsTracker/the clock correlators.
 	smallPacketsDropped   uint64 // datagram too small to plausibly contain a TS packet (+ RTP header, if configured)
@@ -301,18 +324,11 @@ func (t *mediaTracker) scanOneTsPacket(now utc.UTC, pkt *packet.Packet) {
 }
 
 func (t *mediaTracker) Stats() *Stats {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.snapshot(true, utc.Now())
+	return t.Snapshot(&Stats{}, true, utc.Now(), SnapshotOptions{})
 }
 
 func (t *mediaTracker) PeriodStats() *Stats {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	now := utc.Now()
-	s := t.snapshot(false, now)
-	t.resetPeriod(now)
-	return s
+	return t.Snapshot(&Stats{}, false, utc.Now(), SnapshotOptions{})
 }
 
 func (t *mediaTracker) Reset() {
@@ -340,11 +356,15 @@ func (t *mediaTracker) Reset() {
 	t.tsTracker.Reset()
 }
 
-// snapshot builds a Stats for the whole capture (total) or the current period, as of now. Must be called with t.mu
-// held.
-func (t *mediaTracker) snapshot(total bool, now utc.UTC) *Stats {
+// Snapshot populates snap with the cumulative (total=true) or current-period (total=false) stats as of now. See
+// the MediaTracker interface doc for the reuse/reset contract.
+func (t *mediaTracker) Snapshot(snap *Stats, total bool, now utc.UTC, opts SnapshotOptions) *Stats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.start.IsZero() {
-		return &Stats{Source: t.streamId}
+		*snap = Stats{Source: t.streamId}
+		return snap
 	}
 
 	var elapsed time.Duration
@@ -360,43 +380,61 @@ func (t *mediaTracker) snapshot(total bool, now utc.UTC) *Stats {
 	}
 	pps, bps := rates(packets, bytes, elapsed)
 
-	var rate *RateStats
 	if total {
-		rate = &RateStats{
-			PpsMean:   round(t.rateTotal.Mean, 1),
-			PpsStddev: round(stddev(&t.rateTotal), 1),
-			PpsMin:    round(t.rateTotal.Min, 1),
-			PpsMax:    round(t.rateTotal.Max, 1),
-			BpsMean:   uint64(t.bitrateTotal.Mean),
-			BpsStddev: uint64(stddev(&t.bitrateTotal)),
-			BpsMin:    uint64(t.bitrateTotal.Min),
-			BpsMax:    uint64(t.bitrateTotal.Max),
+		if snap.Rate == nil {
+			snap.Rate = &RateStats{}
 		}
-	} else if packets > 0 {
-		t.rateTotal.Update(now, pps)
-		t.bitrateTotal.Update(now, bps)
+		snap.Rate.PpsMean = round(t.rateTotal.Mean, 1)
+		snap.Rate.PpsStddev = round(stddev(&t.rateTotal), 1)
+		snap.Rate.PpsMin = round(t.rateTotal.Min, 1)
+		snap.Rate.PpsMax = round(t.rateTotal.Max, 1)
+		snap.Rate.BpsMean = uint64(t.bitrateTotal.Mean)
+		snap.Rate.BpsStddev = uint64(stddev(&t.bitrateTotal))
+		snap.Rate.BpsMin = uint64(t.bitrateTotal.Min)
+		snap.Rate.BpsMax = uint64(t.bitrateTotal.Max)
+	} else {
+		snap.Rate = nil // period snapshots never populate Rate, same as today
+		if packets > 0 {
+			t.rateTotal.Update(now, pps)
+			t.bitrateTotal.Update(now, bps)
+		}
 	}
 
-	tsStats := t.tsTracker.Stats()
-	s := &Stats{
-		Source:  t.streamId,
-		Elapsed: duration.Spec(elapsed).RoundTo(2),
-		Packets: packets,
-		Bytes:   bytes,
-		Pps:     round(pps, 1),
-		Bitrate: uint64(bps),
-		Rate:    rate,
-		Ipd:     newDistribution(ipdStats, ipdHist),
-		Clocks:  t.clockStats(total),
-		Outages: OutageStats{Count: t.outageCount, TotalMs: t.outageTotal},
-		Errors:  t.errorStats(tsStats),
-	}
-	if total {
-		s.Ts = tsStats
+	// Gather tsTracker's stats into snap.Ts itself when it will be exposed (total, not skipped), or into a
+	// private scratch buffer otherwise (period snapshots never expose Ts; SkipTs skips the expensive walk
+	// either way) - errorStats still needs the result either way to derive Errors.Total/CcErrors/ByPid.
+	var tsStats *mpegts.Stats
+	if total && !opts.SkipTs {
+		if snap.Ts == nil {
+			snap.Ts = &mpegts.Stats{}
+		}
+		tsStats = snap.Ts
 	} else {
-		s.Window = duration.Spec(elapsed).RoundTo(2)
+		snap.Ts = nil
+		if t.tsScratch == nil {
+			t.tsScratch = &mpegts.Stats{}
+		}
+		tsStats = t.tsScratch
 	}
-	return s
+	t.tsTracker.Snapshot(tsStats, !opts.SkipTs)
+
+	snap.Source = t.streamId
+	snap.Elapsed = duration.Spec(elapsed).RoundTo(2)
+	snap.Packets = packets
+	snap.Bytes = bytes
+	snap.Pps = round(pps, 1)
+	snap.Bitrate = uint64(bps)
+	snap.Ipd = newDistribution(ipdStats, ipdHist)
+	snap.Clocks = t.clockStats(snap.Clocks, total)
+	snap.Outages = OutageStats{Count: t.outageCount, TotalMs: t.outageTotal}
+	t.errorStats(&snap.Errors, tsStats)
+	if total {
+		snap.Window = 0
+	} else {
+		snap.Window = duration.Spec(elapsed).RoundTo(2)
+		t.resetPeriod(now)
+	}
+	return snap
 }
 
 func (t *mediaTracker) resetPeriod(now utc.UTC) {
@@ -410,35 +448,38 @@ func (t *mediaTracker) resetPeriod(now utc.UTC) {
 	t.pcrClock.resetPeriod()
 }
 
-// clockStats builds a ClockStats for each active correlation: the RTP timestamp clock (if any) followed by one PCR
-// entry per PCR-bearing PID.
-func (t *mediaTracker) clockStats(total bool) []ClockStats {
-	var stats []ClockStats
+// clockStats builds a ClockStats for each active correlation into dst (reused across calls, see Snapshot): the RTP
+// timestamp clock (if any) followed by one PCR entry per PCR-bearing PID.
+func (t *mediaTracker) clockStats(dst []ClockStats, total bool) []ClockStats {
+	dst = dst[:0]
 	if t.rtpClock != nil {
-		stats = append(stats, t.rtpClock.report(total))
+		dst = append(dst, ClockStats{}) // reuses dst's backing array if it has capacity
+		t.rtpClock.report(&dst[0], total)
 	}
-	return append(stats, t.pcrClock.reports(total)...)
+	// pcrClock.reports appends after whatever's already in dst (the rtp report, if any), starting at len(dst).
+	return t.pcrClock.reports(dst, total)
 }
 
-// errorStats summarizes the transport-stream validation errors and input-integrity conditions accumulated so far.
-func (t *mediaTracker) errorStats(ts *mpegts.Stats) ErrorStats {
-	r := ErrorStats{
-		Total:                 ts.ErrorCount,
-		SmallPacketsDropped:   t.smallPacketsDropped,
-		RtcpPacketsDropped:    t.rtcpPacketsDropped,
-		BadPackets:            t.badPackets,
-		IncompletePackets:     t.incompletePackets,
-		AdaptationFieldErrors: t.adaptationFieldErrors,
-		FaultyPaddingPackets:  t.faultyPaddingPackets,
-		LongHeaders:           t.longHeaders,
-	}
+// errorStats summarizes the transport-stream validation errors and input-integrity conditions accumulated so far
+// into dst (reused across calls, see Snapshot). ts.CcErrors/ts.Streams reflect the cheap running total / the
+// per-PID walk respectively - see TsStreamTracker.Snapshot for when the latter is populated.
+func (t *mediaTracker) errorStats(dst *ErrorStats, ts *mpegts.Stats) {
+	dst.Total = ts.ErrorCount
+	dst.CcErrors = ts.CcErrors
+	dst.SmallPacketsDropped = t.smallPacketsDropped
+	dst.RtcpPacketsDropped = t.rtcpPacketsDropped
+	dst.BadPackets = t.badPackets
+	dst.IncompletePackets = t.incompletePackets
+	dst.AdaptationFieldErrors = t.adaptationFieldErrors
+	dst.FaultyPaddingPackets = t.faultyPaddingPackets
+	dst.LongHeaders = t.longHeaders
+
+	dst.ByPid = dst.ByPid[:0]
 	for _, stream := range ts.Streams {
-		r.CcErrors += stream.CcErrors
 		if stream.CcErrors > 0 {
-			r.ByPid = append(r.ByPid, PidErrors{Pid: stream.Pid, CcErrors: stream.CcErrors})
+			dst.ByPid = append(dst.ByPid, PidErrors{Pid: stream.Pid, CcErrors: stream.CcErrors})
 		}
 	}
-	return r
 }
 
 // isValidPadding reports whether pkt's payload (bytes 4 through 187) is valid 0xFF padding.

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -18,7 +18,6 @@ import (
 	"github.com/eluv-io/common-go/format/duration"
 	"github.com/eluv-io/common-go/media/mpegts"
 	"github.com/eluv-io/common-go/media/pktpool"
-	"github.com/eluv-io/common-go/media/rtp"
 	"github.com/eluv-io/common-go/util/histogram"
 	"github.com/eluv-io/common-go/util/statsutil"
 	"github.com/eluv-io/errors-go"
@@ -90,6 +89,7 @@ func NewMediaTracker(streamId string, cfg Config) MediaTracker {
 		// We feed already-decapsulated TS bytes/packets to the tracker (stripRtp=false), since MediaTracker itself
 		// strips the RTP layer before feeding the tracker.
 		tsTracker:     mpegts.NewTsStreamTracker(streamId, cfg.StatsLogPeriod, false),
+		rawPkt:        pktpool.NewRawPacket(nil),
 		pcrClock:      newPcrCorrelator(cfg.MaxGaps),
 		ipdHistTotal:  newIpdHistogram(),
 		ipdHistPeriod: newIpdHistogram(),
@@ -136,6 +136,11 @@ type mediaTracker struct {
 	// packet counts, continuity-counter errors).
 	tsTracker mpegts.TsStreamTracker
 
+	// rawPkt is owned exclusively by this tracker and reused across TrackDatagram calls so it decodes without
+	// allocating; it aliases the datagram passed to TrackDatagram only for the duration of that call - never
+	// retained after trackLocked returns.
+	rawPkt *pktpool.RawPacket
+
 	// counters for input validation/integrity conditions not covered by tsTracker/the clock correlators.
 	smallPacketsDropped   uint64 // datagram too small to plausibly contain a TS packet (+ RTP header, if configured)
 	rtcpPacketsDropped    uint64 // subset of smallPacketsDropped that looks like a misdirected RTCP packet
@@ -151,46 +156,7 @@ type mediaTracker struct {
 func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-
-	t.recordArrival(now, len(datagram))
-
-	tsBytes := datagram
-	if t.rtpClock != nil {
-		if len(datagram) < rtpTsMinLen {
-			t.smallPacketsDropped++
-			if isRTCP(datagram) {
-				t.rtcpPacketsDropped++
-			}
-			return nil
-		}
-		pkt, err := rtp.ParsePacket(datagram)
-		if err != nil {
-			t.badPackets++
-			t.rtpClock.parseErrors++
-			return err
-		}
-		if t.cfg.OnRtpSample != nil {
-			t.cfg.OnRtpSample(pkt.SequenceNumber, pkt.Timestamp)
-		}
-		if headerLen := len(datagram) - len(pkt.Payload) - int(pkt.PaddingSize); headerLen != 12 {
-			t.longHeaders++
-		}
-		t.rtpClock.record(now, pkt.SequenceNumber, pkt.Timestamp)
-		tsBytes = pkt.Payload
-	} else if len(datagram) < packet.PacketSize {
-		t.smallPacketsDropped++
-		return nil
-	}
-
-	if len(tsBytes)%packet.PacketSize != 0 {
-		t.incompletePackets++
-		return errors.NoTrace("MediaTracker.TrackDatagram", errors.K.Invalid,
-			"reason", "ts payload length is not a multiple of the TS packet size", "len", len(tsBytes))
-	}
-
-	_, errList := t.tsTracker.Track(tsBytes)
-	t.scanTsBytes(now, tsBytes)
-	return errList
+	return t.trackLocked(now, datagram, t.rawPkt.Reset(datagram))
 }
 
 // TrackPacket processes one already-decoded pooled packet received at now (the packet's arrival time), reusing its
@@ -198,8 +164,14 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.trackLocked(now, pkt.Data, pkt)
+}
 
-	datagram := pkt.Data
+// trackLocked contains the RTP/MPEG-TS parsing and stats logic shared by TrackDatagram and TrackPacket - the two
+// differ only in how they obtain a pktpool.Decoder for the datagram (a reused pktpool.RawPacket vs. an
+// already-decoded pktpool.Packet), not in how that decoder's layers are processed. Must be called with t.mu held.
+// datagram is src's full extent, used for the length checks below; src provides the actual layer decoding.
+func (t *mediaTracker) trackLocked(now utc.UTC, datagram []byte, src pktpool.Decoder) error {
 	t.recordArrival(now, len(datagram))
 
 	if t.rtpClock != nil {
@@ -210,7 +182,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 			}
 			return nil
 		}
-		rtpLayer, err := pkt.Rtp()
+		rtpLayer, err := src.Rtp()
 		if err != nil {
 			t.badPackets++
 			t.rtpClock.parseErrors++
@@ -220,7 +192,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 		if hdr.Version != 2 {
 			t.badPackets++
 			t.rtpClock.parseErrors++
-			return errors.NoTrace("MediaTracker.TrackPacket", errors.K.Invalid,
+			return errors.NoTrace("MediaTracker.trackLocked", errors.K.Invalid,
 				"reason", "unsupported RTP version", "version", hdr.Version)
 		}
 		if t.cfg.OnRtpSample != nil {
@@ -235,7 +207,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 		return nil
 	}
 
-	tsLayer, err := pkt.Ts()
+	tsLayer, err := src.Ts()
 	if err != nil {
 		t.incompletePackets++
 		return err
@@ -276,23 +248,9 @@ func (t *mediaTracker) recordArrival(now utc.UTC, n int) {
 	t.lastArrival = now
 }
 
-// scanTsBytes walks the given already-validated (length is a multiple of the TS packet size) raw TS bytes, extracting
-// PCR values and checking null-packet integrity. It stops (and counts a stream-level parse error) at the first
-// TS-misaligned packet, mirroring scanTsPackets's per-packet checks for a caller that only has raw bytes.
-func (t *mediaTracker) scanTsBytes(now utc.UTC, tsBytes []byte) {
-	for off := 0; off+packet.PacketSize <= len(tsBytes); off += packet.PacketSize {
-		if tsBytes[off] != packet.SyncByte {
-			t.pcrClock.parseErrors++
-			return
-		}
-		pkt := (*packet.Packet)(tsBytes[off : off+packet.PacketSize])
-		t.scanOneTsPacket(now, pkt)
-	}
-}
-
 // scanTsPackets walks the given already-parsed TS packets, extracting PCR values and checking null-packet integrity.
 // It does not perform continuity-counter/PID/PMT validation - that's tsTracker's job, fed separately via
-// Track/TrackPackets so the caller controls whether/how re-parsing happens.
+// TrackPackets so the caller controls whether/how re-parsing happens.
 func (t *mediaTracker) scanTsPackets(now utc.UTC, pkts []*packet.Packet) {
 	for _, pkt := range pkts {
 		t.scanOneTsPacket(now, pkt)
@@ -300,8 +258,14 @@ func (t *mediaTracker) scanTsPackets(now utc.UTC, pkts []*packet.Packet) {
 }
 
 // scanOneTsPacket extracts a PCR value from pkt (feeding the PID correlator and the optional OnPcr callback) and, for
-// a null-PID packet, checks that its payload is valid 0xFF padding.
+// a null-PID packet, checks that its payload is valid 0xFF padding. A bad sync byte only drops this one packet (counted
+// via pcrClock.parseErrors) - it does not abort scanning the rest of the caller's packet slice, mirroring how
+// tsTracker.TrackPackets already treats a CheckErrors failure as per-packet, not per-datagram.
 func (t *mediaTracker) scanOneTsPacket(now utc.UTC, pkt *packet.Packet) {
+	if pkt[0] != packet.SyncByte {
+		t.pcrClock.parseErrors++
+		return
+	}
 	if pkt.IsNull() {
 		if !isValidPadding(pkt) {
 			t.faultyPaddingPackets++

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -123,27 +123,36 @@ type mediaTracker struct {
 	streamId string
 	cfg      Config
 
-	start       utc.UTC // arrival time of the first packet
-	lastArrival utc.UTC // arrival time of the previous packet
+	start       utc.UTC // arrival time of the first packet ever tracked - never reset by resetPeriod, only by Reset
+	lastArrival utc.UTC // arrival time of the previous packet, used to compute the next inter-packet delay
 
-	// cumulative counters
-	totalPackets uint64
-	totalBytes   uint64
-	outageCount  uint64
-	outageTotal  duration.Millis
+	// cumulative counters, reset only by Reset (never by resetPeriod/PeriodStats/Snapshot(total: false)). These, and
+	// their periodXxx counterparts below, are the fields recorded for every datagram exactly as received on the wire,
+	// unconditionally, regardless of whether it's later classified as dropped/invalid. That is a *different* signal
+	// from the validation/integrity counters further down (smallPacketsDropped, badPackets, etc.), which only increment
+	// for a datagram/packet these have already counted here - "how much arrived" vs. "how much of what arrived was
+	// valid media".
+	totalPackets uint64          // every datagram TrackDatagram/TrackPacket has ever been called with
+	totalBytes   uint64          // sum of every such datagram's length, in bytes
+	outageCount  uint64          // number of inter-packet gaps >= cfg.OutageThreshold, ever
+	outageTotal  duration.Millis // sum of those gaps' durations
 
-	// cumulative distributions
-	ipdTotal     statsutil.Statistics[duration.Millis]
-	ipdHistTotal *histogram.Histogram[duration.Millis]
-	rateTotal    statsutil.Statistics[float64] // per-period packet rate (packets/s) - captures rate variation
-	bitrateTotal statsutil.Statistics[float64] // per-period bitrate (bits/s) - captures bitrate variation
+	// cumulative distributions, reset only by Reset.
+	ipdTotal     statsutil.Statistics[duration.Millis] // inter-packet-delay distribution over the whole capture
+	ipdHistTotal *histogram.Histogram[duration.Millis] // same, as a histogram (for percentiles)
+	rateTotal    statsutil.Statistics[float64]         // per-period packet rate (packets/s) - captures rate variation
+	bitrateTotal statsutil.Statistics[float64]         // per-period bitrate (bits/s) - captures bitrate variation
 
-	// current period counters and distributions (reset on each PeriodStats call)
-	periodStart   utc.UTC
-	periodPackets uint64
-	periodBytes   uint64
-	ipdPeriod     statsutil.Statistics[duration.Millis]
-	ipdHistPeriod *histogram.Histogram[duration.Millis]
+	// current period counters and distributions: the periodXxx counterpart of each cumulative field above,
+	// tracking the exact same thing but reset to zero by resetPeriod on each PeriodStats/Snapshot(total: false)
+	// call, so a caller polling periodically gets "since I last asked" instead of "since the stream started".
+	periodStart       utc.UTC                               // start of the current period
+	periodPackets     uint64                                // totalPackets' counterpart, this period only
+	periodBytes       uint64                                // totalBytes' counterpart, this period only
+	periodOutageCount uint64                                // outageCount's counterpart, this period only
+	periodOutageTotal duration.Millis                       // outageTotal's counterpart, this period only
+	ipdPeriod         statsutil.Statistics[duration.Millis] // ipdTotal's counterpart, this period only
+	ipdHistPeriod     *histogram.Histogram[duration.Millis] // ipdHistTotal's counterpart, this period only
 
 	// arrival vs media-clock correlation. The PCR correlation is always present (extracted from the MPEG-TS
 	// payload); for RTP sources the RTP-timestamp correlation is present too, so both clocks are correlated.
@@ -165,6 +174,9 @@ type mediaTracker struct {
 	tsScratch *mpegts.Stats
 
 	// counters for input validation/integrity conditions not covered by tsTracker/the clock correlators.
+	// Cumulative only - no periodXxx counterpart, unlike the arrival counters above. Each of these increments for
+	// a datagram/packet that recordArrival has *already* counted in totalPackets/totalBytes above; they're the
+	// "how much of what arrived was actually valid media" half of that pair, not a separate arrival count.
 	smallPacketsDropped   uint64 // datagram too small to plausibly contain a TS packet (+ RTP header, if configured)
 	rtcpPacketsDropped    uint64 // subset of smallPacketsDropped that looks like a misdirected RTCP packet
 	badPackets            uint64 // RTP header failed to parse, or carried an unsupported RTP version
@@ -246,6 +258,13 @@ func (t *mediaTracker) trackLocked(now utc.UTC, datagram []byte, src pktpool.Dec
 // statistics. now is the packet's arrival time, as supplied by the caller (never sampled internally), so callers
 // whose packets pass through an intermediate queue (e.g. a channel) can supply the true network arrival time rather
 // than the time TrackDatagram/TrackPacket happens to be invoked.
+//
+// trackLocked calls this unconditionally, before any of its own drop/validation checks - so Packets/Bytes/Pps/
+// Bitrate/Ipd/Outages count every datagram exactly as received on the wire, including ones later classified as
+// dropped or invalid (too small, malformed RTP, misdirected RTCP, ...). This is deliberate, not an oversight: it's
+// the network-level arrival signal (useful for spotting e.g. a flood of garbage/misdirected traffic), distinct from
+// "how much valid media arrived" - which is tracked separately via smallPacketsDropped/rtcpPacketsDropped/
+// badPackets/incompletePackets/etc. Do not move this call after validation without considering both signals.
 func (t *mediaTracker) recordArrival(now utc.UTC, n int) {
 	if t.start.IsZero() {
 		t.start = now
@@ -266,6 +285,8 @@ func (t *mediaTracker) recordArrival(now utc.UTC, n int) {
 		if ipd >= t.cfg.OutageThreshold {
 			t.outageCount++
 			t.outageTotal += duration.Millis(ipd)
+			t.periodOutageCount++
+			t.periodOutageTotal += duration.Millis(ipd)
 		}
 	}
 	t.lastArrival = now
@@ -339,6 +360,7 @@ func (t *mediaTracker) Reset() {
 	t.totalPackets, t.totalBytes = 0, 0
 	t.outageCount, t.outageTotal = 0, 0
 	t.periodPackets, t.periodBytes = 0, 0
+	t.periodOutageCount, t.periodOutageTotal = 0, 0
 	t.ipdTotal = statsutil.Statistics[duration.Millis]{}
 	t.ipdPeriod = statsutil.Statistics[duration.Millis]{}
 	t.ipdHistTotal.Clear()
@@ -371,7 +393,7 @@ func (t *mediaTracker) Snapshot(snap *Stats, total bool, now utc.UTC, opts Snaps
 	var packets, bytes uint64
 	ipdStats, ipdHist := &t.ipdPeriod, t.ipdHistPeriod
 	if total {
-		elapsed = utc.Since(t.start)
+		elapsed = now.Sub(t.start)
 		packets, bytes = t.totalPackets, t.totalBytes
 		ipdStats, ipdHist = &t.ipdTotal, t.ipdHistTotal
 	} else {
@@ -426,7 +448,11 @@ func (t *mediaTracker) Snapshot(snap *Stats, total bool, now utc.UTC, opts Snaps
 	snap.Bitrate = uint64(bps)
 	snap.Ipd = newDistribution(ipdStats, ipdHist)
 	snap.Clocks = t.clockStats(snap.Clocks, total)
-	snap.Outages = OutageStats{Count: t.outageCount, TotalMs: t.outageTotal}
+	if total {
+		snap.Outages = OutageStats{Count: t.outageCount, TotalMs: t.outageTotal}
+	} else {
+		snap.Outages = OutageStats{Count: t.periodOutageCount, TotalMs: t.periodOutageTotal}
+	}
 	t.errorStats(&snap.Errors, tsStats)
 	if total {
 		snap.Window = 0
@@ -440,6 +466,7 @@ func (t *mediaTracker) Snapshot(snap *Stats, total bool, now utc.UTC, opts Snaps
 func (t *mediaTracker) resetPeriod(now utc.UTC) {
 	t.periodStart = now
 	t.periodPackets, t.periodBytes = 0, 0
+	t.periodOutageCount, t.periodOutageTotal = 0, 0
 	t.ipdPeriod = statsutil.Statistics[duration.Millis]{}
 	t.ipdHistPeriod.Clear()
 	if t.rtpClock != nil {
@@ -482,9 +509,22 @@ func (t *mediaTracker) errorStats(dst *ErrorStats, ts *mpegts.Stats) {
 	}
 }
 
-// isValidPadding reports whether pkt's payload (bytes 4 through 187) is valid 0xFF padding.
+// isValidPadding reports whether pkt's payload is valid 0xFF padding. A null-PID packet is not required to be
+// payload-only (adaptation_field_control 01) - the spec permits an adaptation field here too (10/11), in which case
+// the payload starts later than byte 4, or there may be no payload at all.
 func isValidPadding(pkt *packet.Packet) bool {
-	for i := 4; i < packet.PacketSize; i++ {
+	payloadStart := 4
+	if pkt.HasAdaptationField() {
+		af, err := pkt.AdaptationField()
+		if err != nil {
+			return false
+		}
+		payloadStart = 4 + 1 + af.Length() // TS header + the length byte itself + its content
+	}
+	if !pkt.HasPayload() {
+		return true // adaptation-field-only null packet: no payload bytes to validate
+	}
+	for i := payloadStart; i < packet.PacketSize; i++ {
 		if pkt[i] != 0xFF {
 			return false
 		}

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -34,13 +34,6 @@ const defaultMaxGaps = 100
 // rtpTsMinLen is the minimum datagram length for RTP-wrapped MPEG-TS: an RTP header plus at least one TS packet.
 const rtpTsMinLen = 12 + packet.PacketSize
 
-// ErrDropped is returned by TrackDatagram/TrackPacket when the datagram was too small to plausibly contain valid
-// media data and was dropped before any parsing was attempted (see ErrorStats.SmallPacketsDropped/RtcpPacketsDropped).
-// A caller that only forwards/writes successfully-tracked datagrams should treat any non-nil return value - including
-// ErrDropped - the same way (skip); a caller that specifically needs to distinguish "dropped outright" from "parsed
-// but found invalid" can compare against this sentinel.
-var ErrDropped = errors.NoTrace("MediaTracker", errors.K.Invalid, "reason", "datagram dropped: too small")
-
 // Config configures a MediaTracker.
 type Config struct {
 	// Rtp selects whether the input is RTP-wrapped MPEG-TS. When true, the RTP timestamp clock is correlated in
@@ -146,7 +139,7 @@ type mediaTracker struct {
 	// counters for input validation/integrity conditions not covered by tsTracker/the clock correlators.
 	smallPacketsDropped   uint64 // datagram too small to plausibly contain a TS packet (+ RTP header, if configured)
 	rtcpPacketsDropped    uint64 // subset of smallPacketsDropped that looks like a misdirected RTCP packet
-	badPackets            uint64 // datagram dropped due to a malformed RTP header or a bad TS packet within it
+	badPackets            uint64 // RTP header failed to parse, or carried an unsupported RTP version
 	incompletePackets     uint64 // TS payload length not a multiple of the TS packet size
 	adaptationFieldErrors uint64 // TS adaptation-field/PCR parse errors
 	faultyPaddingPackets  uint64 // null-PID packet whose payload is not valid 0xFF padding
@@ -168,7 +161,7 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 			if isRTCP(datagram) {
 				t.rtcpPacketsDropped++
 			}
-			return ErrDropped
+			return nil
 		}
 		pkt, err := rtp.ParsePacket(datagram)
 		if err != nil {
@@ -186,7 +179,7 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 		tsBytes = pkt.Payload
 	} else if len(datagram) < packet.PacketSize {
 		t.smallPacketsDropped++
-		return ErrDropped
+		return nil
 	}
 
 	if len(tsBytes)%packet.PacketSize != 0 {
@@ -196,9 +189,6 @@ func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
 	}
 
 	_, errList := t.tsTracker.Track(tsBytes)
-	if errList != nil {
-		t.badPackets++
-	}
 	t.scanTsBytes(now, tsBytes)
 	return errList
 }
@@ -218,7 +208,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 			if isRTCP(datagram) {
 				t.rtcpPacketsDropped++
 			}
-			return ErrDropped
+			return nil
 		}
 		rtpLayer, err := pkt.Rtp()
 		if err != nil {
@@ -242,7 +232,7 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 		t.rtpClock.record(now, hdr.SequenceNumber, hdr.Timestamp)
 	} else if len(datagram) < packet.PacketSize {
 		t.smallPacketsDropped++
-		return ErrDropped
+		return nil
 	}
 
 	tsLayer, err := pkt.Ts()
@@ -253,9 +243,6 @@ func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
 	tsPkts := tsLayer.Packets()
 
 	_, errList := t.tsTracker.TrackPackets(tsPkts)
-	if errList != nil {
-		t.badPackets++
-	}
 	t.scanTsPackets(now, tsPkts)
 	return errList
 }

--- a/media/tracker/tracker.go
+++ b/media/tracker/tracker.go
@@ -1,0 +1,504 @@
+// Package tracker provides MediaTracker, a component that tracks the timing and integrity of a live media stream
+// received over the network. It composes the existing mpegts.TsStreamTracker (MPEG-TS continuity-counter/PID/PMT
+// validation) with arrival-vs-media-clock correlation (skew/jitter/drift, for both RTP timestamps and per-PID MPEG-TS
+// PCR) and datagram-level timing statistics (packet rate, bitrate, inter-packet delay, outages).
+//
+// MediaTracker exposes two entry points for feeding it packets: TrackDatagram, for a caller that only has the raw
+// network bytes (e.g. a CLI probe reading from a socket), and TrackPacket, for a caller that already holds a
+// decoded pktpool.Packet (e.g. a media pipeline that parses once and fans out to multiple consumers) - the latter
+// avoids re-parsing the RTP/MPEG-TS layers a second time.
+package tracker
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Comcast/gots/v2/packet"
+
+	"github.com/eluv-io/common-go/format/duration"
+	"github.com/eluv-io/common-go/media/mpegts"
+	"github.com/eluv-io/common-go/media/pktpool"
+	"github.com/eluv-io/common-go/media/rtp"
+	"github.com/eluv-io/common-go/util/histogram"
+	"github.com/eluv-io/common-go/util/statsutil"
+	"github.com/eluv-io/errors-go"
+	"github.com/eluv-io/utc-go"
+)
+
+// defaultOutageThreshold is the default minimum gap between two consecutive packets counted as an outage.
+const defaultOutageThreshold = time.Second
+
+// defaultMaxGaps is the default bound on the number of RTP Gap events retained in a ClockStats.
+const defaultMaxGaps = 100
+
+// rtpTsMinLen is the minimum datagram length for RTP-wrapped MPEG-TS: an RTP header plus at least one TS packet.
+const rtpTsMinLen = 12 + packet.PacketSize
+
+// Config configures a MediaTracker.
+type Config struct {
+	// Rtp selects whether the input is RTP-wrapped MPEG-TS. When true, the RTP timestamp clock is correlated in
+	// addition to the per-PID MPEG-TS PCR clock, which is always tracked.
+	Rtp bool
+
+	// StatsLogPeriod, when > 0, enables the embedded mpegts.TsStreamTracker's own periodic stats logging.
+	StatsLogPeriod time.Duration
+
+	// OutageThreshold is the minimum gap between two consecutive packets counted as an outage. Defaults to 1s.
+	OutageThreshold time.Duration
+
+	// MaxGaps bounds the number of RTP Gap events retained in ClockStats.Gaps; once the bound is reached, further
+	// gaps are only counted (GapsOverflow), not retained. Defaults to 100.
+	MaxGaps int
+
+	// OnRtpSample, if non-nil, is called for every RTP packet's raw header fields (sequence number and timestamp,
+	// in packet order), before gap detection or unwrapping. Used by a caller that needs the raw per-packet timing
+	// inputs, e.g. a debug trace.
+	OnRtpSample func(seq uint16, ts uint32)
+
+	// OnPcr, if non-nil, is called for every PCR value extracted from the stream (in packet order), tagged with the
+	// PID that carried it. Used by a caller that needs the raw per-packet timing inputs, e.g. a debug trace.
+	OnPcr func(pid int, pcr uint64)
+}
+
+// MediaTracker tracks the timing and integrity of a live media stream. See the package doc for an overview.
+type MediaTracker interface {
+	// TrackDatagram processes one raw network datagram received at now (the datagram's arrival time), parsing the
+	// RTP header (if the tracker is configured for RTP) and the contained MPEG-TS packets.
+	TrackDatagram(now utc.UTC, datagram []byte) error
+	// TrackPacket processes one already-decoded pooled packet received at now (the packet's arrival time), reusing
+	// its already-parsed RTP/MPEG-TS layers instead of re-parsing pkt.Data.
+	TrackPacket(now utc.UTC, pkt *pktpool.Packet) error
+	// Stats returns the cumulative stats for the whole capture.
+	Stats() *Stats
+	// PeriodStats returns the stats for the current reporting period and resets the period window.
+	PeriodStats() *Stats
+	// Reset resets the tracker state, clearing all statistics.
+	Reset()
+}
+
+// NewMediaTracker creates a MediaTracker for a single stream.
+func NewMediaTracker(streamId string, cfg Config) MediaTracker {
+	if cfg.OutageThreshold <= 0 {
+		cfg.OutageThreshold = defaultOutageThreshold
+	}
+	if cfg.MaxGaps <= 0 {
+		cfg.MaxGaps = defaultMaxGaps
+	}
+	t := &mediaTracker{
+		streamId: streamId,
+		cfg:      cfg,
+		// We feed already-decapsulated TS bytes/packets to the tracker (stripRtp=false), since MediaTracker itself
+		// strips the RTP layer before feeding the tracker.
+		tsTracker:     mpegts.NewTsStreamTracker(streamId, cfg.StatsLogPeriod, false),
+		pcrClock:      newPcrCorrelator(cfg.MaxGaps),
+		ipdHistTotal:  newIpdHistogram(),
+		ipdHistPeriod: newIpdHistogram(),
+	}
+	if cfg.Rtp {
+		t.rtpClock = newRtpCorrelator(cfg.MaxGaps)
+	}
+	return t
+}
+
+type mediaTracker struct {
+	mu       sync.Mutex
+	streamId string
+	cfg      Config
+
+	start       utc.UTC // arrival time of the first packet
+	lastArrival utc.UTC // arrival time of the previous packet
+
+	// cumulative counters
+	totalPackets uint64
+	totalBytes   uint64
+	outageCount  uint64
+	outageTotal  duration.Millis
+
+	// cumulative distributions
+	ipdTotal     statsutil.Statistics[duration.Millis]
+	ipdHistTotal *histogram.Histogram[duration.Millis]
+	rateTotal    statsutil.Statistics[float64] // per-period packet rate (packets/s) - captures rate variation
+	bitrateTotal statsutil.Statistics[float64] // per-period bitrate (bits/s) - captures bitrate variation
+
+	// current period counters and distributions (reset on each PeriodStats call)
+	periodStart   utc.UTC
+	periodPackets uint64
+	periodBytes   uint64
+	ipdPeriod     statsutil.Statistics[duration.Millis]
+	ipdHistPeriod *histogram.Histogram[duration.Millis]
+
+	// arrival vs media-clock correlation. The PCR correlation is always present (extracted from the MPEG-TS
+	// payload); for RTP sources the RTP-timestamp correlation is present too, so both clocks are correlated.
+	rtpClock *rtpCorrelator // nil for raw MPEG-TS sources
+	pcrClock *pcrCorrelator
+
+	// tsTracker validates the transport stream and collects per-program/PID structure (stream types from the PMT,
+	// packet counts, continuity-counter errors).
+	tsTracker mpegts.TsStreamTracker
+
+	// counters for input validation/integrity conditions not covered by tsTracker/the clock correlators.
+	smallPacketsDropped   uint64 // datagram too small to plausibly contain a TS packet (+ RTP header, if configured)
+	rtcpPacketsDropped    uint64 // subset of smallPacketsDropped that looks like a misdirected RTCP packet
+	badPackets            uint64 // datagram dropped due to a malformed RTP header or a bad TS packet within it
+	incompletePackets     uint64 // TS payload length not a multiple of the TS packet size
+	adaptationFieldErrors uint64 // TS adaptation-field/PCR parse errors
+	faultyPaddingPackets  uint64 // null-PID packet whose payload is not valid 0xFF padding
+	longHeaders           uint64 // RTP header longer than the expected 12 bytes (extension-bearing packets)
+}
+
+// TrackDatagram processes one raw network datagram received at now (the datagram's arrival time), parsing the RTP
+// header (if the tracker is configured for RTP) and the contained MPEG-TS packets.
+func (t *mediaTracker) TrackDatagram(now utc.UTC, datagram []byte) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.recordArrival(now, len(datagram))
+
+	tsBytes := datagram
+	if t.rtpClock != nil {
+		if len(datagram) < rtpTsMinLen {
+			t.smallPacketsDropped++
+			if isRTCP(datagram) {
+				t.rtcpPacketsDropped++
+			}
+			return nil
+		}
+		pkt, err := rtp.ParsePacket(datagram)
+		if err != nil {
+			t.badPackets++
+			t.rtpClock.parseErrors++
+			return err
+		}
+		if t.cfg.OnRtpSample != nil {
+			t.cfg.OnRtpSample(pkt.SequenceNumber, pkt.Timestamp)
+		}
+		if headerLen := len(datagram) - len(pkt.Payload) - int(pkt.PaddingSize); headerLen != 12 {
+			t.longHeaders++
+		}
+		t.rtpClock.record(now, pkt.SequenceNumber, pkt.Timestamp)
+		tsBytes = pkt.Payload
+	} else if len(datagram) < packet.PacketSize {
+		t.smallPacketsDropped++
+		return nil
+	}
+
+	if len(tsBytes)%packet.PacketSize != 0 {
+		t.incompletePackets++
+		return errors.NoTrace("MediaTracker.TrackDatagram", errors.K.Invalid,
+			"reason", "ts payload length is not a multiple of the TS packet size", "len", len(tsBytes))
+	}
+
+	_, errList := t.tsTracker.Track(tsBytes)
+	if errList != nil {
+		t.badPackets++
+	}
+	t.scanTsBytes(now, tsBytes)
+	return errList
+}
+
+// TrackPacket processes one already-decoded pooled packet received at now (the packet's arrival time), reusing its
+// already-parsed RTP/MPEG-TS layers - see pktpool.Packet's layer-decoding contract - instead of re-parsing pkt.Data.
+func (t *mediaTracker) TrackPacket(now utc.UTC, pkt *pktpool.Packet) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	datagram := pkt.Data
+	t.recordArrival(now, len(datagram))
+
+	if t.rtpClock != nil {
+		if len(datagram) < rtpTsMinLen {
+			t.smallPacketsDropped++
+			if isRTCP(datagram) {
+				t.rtcpPacketsDropped++
+			}
+			return nil
+		}
+		rtpLayer, err := pkt.Rtp()
+		if err != nil {
+			t.badPackets++
+			t.rtpClock.parseErrors++
+			return err
+		}
+		hdr := rtpLayer.Packet().Header
+		if hdr.Version != 2 {
+			t.badPackets++
+			t.rtpClock.parseErrors++
+			return errors.NoTrace("MediaTracker.TrackPacket", errors.K.Invalid,
+				"reason", "unsupported RTP version", "version", hdr.Version)
+		}
+		if t.cfg.OnRtpSample != nil {
+			t.cfg.OnRtpSample(hdr.SequenceNumber, hdr.Timestamp)
+		}
+		if headerLen := len(datagram) - len(rtpLayer.Payload) - int(hdr.PaddingSize); headerLen != 12 {
+			t.longHeaders++
+		}
+		t.rtpClock.record(now, hdr.SequenceNumber, hdr.Timestamp)
+	} else if len(datagram) < packet.PacketSize {
+		t.smallPacketsDropped++
+		return nil
+	}
+
+	tsLayer, err := pkt.Ts()
+	if err != nil {
+		t.incompletePackets++
+		return err
+	}
+	tsPkts := tsLayer.Packets()
+
+	_, errList := t.tsTracker.TrackPackets(tsPkts)
+	if errList != nil {
+		t.badPackets++
+	}
+	t.scanTsPackets(now, tsPkts)
+	return errList
+}
+
+// recordArrival folds a single packet's arrival into the packet/byte counters and the inter-packet-delay/outage
+// statistics. now is the packet's arrival time, as supplied by the caller (never sampled internally), so callers
+// whose packets pass through an intermediate queue (e.g. a channel) can supply the true network arrival time rather
+// than the time TrackDatagram/TrackPacket happens to be invoked.
+func (t *mediaTracker) recordArrival(now utc.UTC, n int) {
+	if t.start.IsZero() {
+		t.start = now
+		t.periodStart = now
+	}
+	t.totalPackets++
+	t.totalBytes += uint64(n)
+	t.periodPackets++
+	t.periodBytes += uint64(n)
+
+	if !t.lastArrival.IsZero() {
+		ipd := now.Sub(t.lastArrival)
+		ipdMs := duration.Millis(ipd)
+		t.ipdTotal.Update(now, ipdMs)
+		t.ipdPeriod.Update(now, ipdMs)
+		t.ipdHistTotal.Observe(ipdMs)
+		t.ipdHistPeriod.Observe(ipdMs)
+		if ipd >= t.cfg.OutageThreshold {
+			t.outageCount++
+			t.outageTotal += duration.Millis(ipd)
+		}
+	}
+	t.lastArrival = now
+}
+
+// scanTsBytes walks the given already-validated (length is a multiple of the TS packet size) raw TS bytes, extracting
+// PCR values and checking null-packet integrity. It stops (and counts a stream-level parse error) at the first
+// TS-misaligned packet, mirroring scanTsPackets's per-packet checks for a caller that only has raw bytes.
+func (t *mediaTracker) scanTsBytes(now utc.UTC, tsBytes []byte) {
+	for off := 0; off+packet.PacketSize <= len(tsBytes); off += packet.PacketSize {
+		if tsBytes[off] != packet.SyncByte {
+			t.pcrClock.parseErrors++
+			return
+		}
+		pkt := (*packet.Packet)(tsBytes[off : off+packet.PacketSize])
+		t.scanOneTsPacket(now, pkt)
+	}
+}
+
+// scanTsPackets walks the given already-parsed TS packets, extracting PCR values and checking null-packet integrity.
+// It does not perform continuity-counter/PID/PMT validation - that's tsTracker's job, fed separately via
+// Track/TrackPackets so the caller controls whether/how re-parsing happens.
+func (t *mediaTracker) scanTsPackets(now utc.UTC, pkts []*packet.Packet) {
+	for _, pkt := range pkts {
+		t.scanOneTsPacket(now, pkt)
+	}
+}
+
+// scanOneTsPacket extracts a PCR value from pkt (feeding the PID correlator and the optional OnPcr callback) and, for
+// a null-PID packet, checks that its payload is valid 0xFF padding.
+func (t *mediaTracker) scanOneTsPacket(now utc.UTC, pkt *packet.Packet) {
+	if pkt.IsNull() {
+		if !isValidPadding(pkt) {
+			t.faultyPaddingPackets++
+		}
+		return
+	}
+	if !pkt.HasAdaptationField() {
+		return
+	}
+	af, err := pkt.AdaptationField()
+	if err != nil {
+		t.adaptationFieldErrors++
+		return
+	}
+	hasPcr, err := af.HasPCR()
+	if err != nil {
+		t.adaptationFieldErrors++
+		return
+	} else if !hasPcr {
+		return
+	}
+	pcr, err := af.PCR()
+	if err != nil {
+		t.adaptationFieldErrors++
+		return
+	}
+
+	pid := pkt.PID()
+	if t.cfg.OnPcr != nil {
+		t.cfg.OnPcr(pid, pcr)
+	}
+	t.pcrClock.forPid(pid).record(now, pcr)
+}
+
+func (t *mediaTracker) Stats() *Stats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.snapshot(true, utc.Now())
+}
+
+func (t *mediaTracker) PeriodStats() *Stats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := utc.Now()
+	s := t.snapshot(false, now)
+	t.resetPeriod(now)
+	return s
+}
+
+func (t *mediaTracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.start, t.lastArrival, t.periodStart = utc.Zero, utc.Zero, utc.Zero
+	t.totalPackets, t.totalBytes = 0, 0
+	t.outageCount, t.outageTotal = 0, 0
+	t.periodPackets, t.periodBytes = 0, 0
+	t.ipdTotal = statsutil.Statistics[duration.Millis]{}
+	t.ipdPeriod = statsutil.Statistics[duration.Millis]{}
+	t.ipdHistTotal.Clear()
+	t.ipdHistPeriod.Clear()
+	t.rateTotal = statsutil.Statistics[float64]{}
+	t.bitrateTotal = statsutil.Statistics[float64]{}
+	t.smallPacketsDropped, t.rtcpPacketsDropped = 0, 0
+	t.badPackets, t.incompletePackets, t.adaptationFieldErrors = 0, 0, 0
+	t.faultyPaddingPackets, t.longHeaders = 0, 0
+
+	if t.rtpClock != nil {
+		t.rtpClock = newRtpCorrelator(t.cfg.MaxGaps)
+	}
+	t.pcrClock = newPcrCorrelator(t.cfg.MaxGaps)
+	t.tsTracker.Reset()
+}
+
+// snapshot builds a Stats for the whole capture (total) or the current period, as of now. Must be called with t.mu
+// held.
+func (t *mediaTracker) snapshot(total bool, now utc.UTC) *Stats {
+	if t.start.IsZero() {
+		return &Stats{Source: t.streamId}
+	}
+
+	var elapsed time.Duration
+	var packets, bytes uint64
+	ipdStats, ipdHist := &t.ipdPeriod, t.ipdHistPeriod
+	if total {
+		elapsed = utc.Since(t.start)
+		packets, bytes = t.totalPackets, t.totalBytes
+		ipdStats, ipdHist = &t.ipdTotal, t.ipdHistTotal
+	} else {
+		elapsed = now.Sub(t.periodStart)
+		packets, bytes = t.periodPackets, t.periodBytes
+	}
+	pps, bps := rates(packets, bytes, elapsed)
+
+	var rate *RateStats
+	if total {
+		rate = &RateStats{
+			PpsMean:   round(t.rateTotal.Mean, 1),
+			PpsStddev: round(stddev(&t.rateTotal), 1),
+			PpsMin:    round(t.rateTotal.Min, 1),
+			PpsMax:    round(t.rateTotal.Max, 1),
+			BpsMean:   uint64(t.bitrateTotal.Mean),
+			BpsStddev: uint64(stddev(&t.bitrateTotal)),
+			BpsMin:    uint64(t.bitrateTotal.Min),
+			BpsMax:    uint64(t.bitrateTotal.Max),
+		}
+	} else if packets > 0 {
+		t.rateTotal.Update(now, pps)
+		t.bitrateTotal.Update(now, bps)
+	}
+
+	tsStats := t.tsTracker.Stats()
+	s := &Stats{
+		Source:  t.streamId,
+		Elapsed: duration.Spec(elapsed).RoundTo(2),
+		Packets: packets,
+		Bytes:   bytes,
+		Pps:     round(pps, 1),
+		Bitrate: uint64(bps),
+		Rate:    rate,
+		Ipd:     newDistribution(ipdStats, ipdHist),
+		Clocks:  t.clockStats(total),
+		Outages: OutageStats{Count: t.outageCount, TotalMs: t.outageTotal},
+		Errors:  t.errorStats(tsStats),
+	}
+	if total {
+		s.Ts = tsStats
+	} else {
+		s.Window = duration.Spec(elapsed).RoundTo(2)
+	}
+	return s
+}
+
+func (t *mediaTracker) resetPeriod(now utc.UTC) {
+	t.periodStart = now
+	t.periodPackets, t.periodBytes = 0, 0
+	t.ipdPeriod = statsutil.Statistics[duration.Millis]{}
+	t.ipdHistPeriod.Clear()
+	if t.rtpClock != nil {
+		t.rtpClock.resetPeriod()
+	}
+	t.pcrClock.resetPeriod()
+}
+
+// clockStats builds a ClockStats for each active correlation: the RTP timestamp clock (if any) followed by one PCR
+// entry per PCR-bearing PID.
+func (t *mediaTracker) clockStats(total bool) []ClockStats {
+	var stats []ClockStats
+	if t.rtpClock != nil {
+		stats = append(stats, t.rtpClock.report(total))
+	}
+	return append(stats, t.pcrClock.reports(total)...)
+}
+
+// errorStats summarizes the transport-stream validation errors and input-integrity conditions accumulated so far.
+func (t *mediaTracker) errorStats(ts *mpegts.Stats) ErrorStats {
+	r := ErrorStats{
+		Total:                 ts.ErrorCount,
+		SmallPacketsDropped:   t.smallPacketsDropped,
+		RtcpPacketsDropped:    t.rtcpPacketsDropped,
+		BadPackets:            t.badPackets,
+		IncompletePackets:     t.incompletePackets,
+		AdaptationFieldErrors: t.adaptationFieldErrors,
+		FaultyPaddingPackets:  t.faultyPaddingPackets,
+		LongHeaders:           t.longHeaders,
+	}
+	for _, stream := range ts.Streams {
+		r.CcErrors += stream.CcErrors
+		if stream.CcErrors > 0 {
+			r.ByPid = append(r.ByPid, PidErrors{Pid: stream.Pid, CcErrors: stream.CcErrors})
+		}
+	}
+	return r
+}
+
+// isValidPadding reports whether pkt's payload (bytes 4 through 187) is valid 0xFF padding.
+func isValidPadding(pkt *packet.Packet) bool {
+	for i := 4; i < packet.PacketSize; i++ {
+		if pkt[i] != 0xFF {
+			return false
+		}
+	}
+	return true
+}
+
+// isRTCP heuristically identifies an RTCP packet by its payload-type byte, to distinguish a genuinely malformed small
+// datagram from an RTCP packet misdirected onto the media socket.
+func isRTCP(data []byte) bool {
+	if len(data) < 2 {
+		return false
+	}
+	pt := data[1]
+	return pt >= 200 && pt <= 204
+}

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -227,13 +227,13 @@ func TestMediaTracker_SmallPacketsDropped(t *testing.T) {
 	tr := NewMediaTracker("test", Config{Rtp: true})
 
 	// too small to be RTP-wrapped MPEG-TS, and not RTCP-shaped
-	require.ErrorIs(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 0x00}), ErrDropped)
+	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 0x00}))
 	s := tr.Stats()
 	require.EqualValues(t, 1, s.Errors.SmallPacketsDropped)
 	require.EqualValues(t, 0, s.Errors.RtcpPacketsDropped)
 
 	// small and RTCP-shaped (payload type 200 = SR)
-	require.ErrorIs(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 200}), ErrDropped)
+	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 200}))
 	s = tr.Stats()
 	require.EqualValues(t, 2, s.Errors.SmallPacketsDropped)
 	require.EqualValues(t, 1, s.Errors.RtcpPacketsDropped)

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -1,0 +1,383 @@
+package tracker
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/Comcast/gots/v2/packet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/common-go/format/duration"
+	"github.com/eluv-io/common-go/media/mpegts"
+	"github.com/eluv-io/common-go/media/pktpool"
+	"github.com/eluv-io/common-go/media/rtp"
+	"github.com/eluv-io/utc-go"
+)
+
+// TestClockCorrelator_Drift feeds a perfectly regular media clock that runs 100 ppm faster than wall clock and
+// verifies the estimated drift and skew. Inputs are exact, so the assertions are tight. Ported from
+// content-fabric's qfab/cmd/media/probe/probe_test.go to document the sign convention this package inherited.
+func TestClockCorrelator_Drift(t *testing.T) {
+	c := newClockCorrelator("rtp", rtp.TicksToDuration) // RTP: 90 kHz clock
+
+	base := utc.Now()
+	const ticksPerSecond = 90009 // 90000 ticks/s + 100 ppm
+
+	for i := 0; i <= 10; i++ {
+		c.sample(base.Add(time.Duration(i)*time.Second), int64(i*ticksPerSecond))
+	}
+
+	require.EqualValues(t, 10, c.samples)
+	require.InDelta(t, 100, c.driftPpm(), 0.5, "media clock runs ~100 ppm fast")
+
+	// media advances faster than wall, so arrival falls progressively behind media => negative skew.
+	require.Less(t, c.skewTotal.Mean, duration.Millis(0))
+	require.InDelta(t, -1.0, c.lastSkew.AsFloat(), 0.01, "at t=10s the skew is -10s*100ppm = -1ms")
+}
+
+// TestMediaTracker_RawTs drives a raw (non-RTP) MPEG-TS source and verifies the aggregate stats and the PCR
+// correlation, mirroring content-fabric's TestProbe_UDP.
+func TestMediaTracker_RawTs(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+
+	base := utc.Now()
+	var pcr uint64 = 1_000_000
+	const n = 20
+	for i := 0; i < n; i++ {
+		dg, _ := tsDatagramWithPCR(pcr)
+		// The synthetic fixture reuses a fixed continuity counter, so from the second datagram onward
+		// TrackDatagram legitimately returns a continuity-counter error - not asserted here, see
+		// TestMediaTracker_MultiProgramPCR for continuity-counter-error coverage.
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	s := tr.Stats()
+	require.EqualValues(t, n, s.Packets)
+	require.Greater(t, s.Pps, 0.0)
+	require.Greater(t, s.Bitrate, uint64(0))
+	require.Greater(t, s.Ipd.Count, uint64(0))
+	require.Len(t, s.Clocks, 1, "raw TS source has only the PCR correlation")
+	require.Equal(t, "pcr", s.Clocks[0].Source)
+	require.Greater(t, s.Clocks[0].Samples, uint64(0), "PCR samples must be correlated")
+}
+
+// TestMediaTracker_RTP drives an RTP-wrapped MPEG-TS source and verifies that both the RTP-timestamp and PCR clocks
+// are correlated, mirroring content-fabric's TestProbe_RTP.
+func TestMediaTracker_RTP(t *testing.T) {
+	tr := NewMediaTracker("test", Config{Rtp: true})
+
+	base := utc.Now()
+	var (
+		seq     uint16
+		rtpTs   uint32 = 1_000
+		pcrBase uint64 = 1_000_000
+	)
+	const n = 20
+	for i := 0; i < n; i++ {
+		dg, _ := tsDatagramWithPCR(pcrBase)
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), rtpWrap(seq, rtpTs, dg))
+		seq++
+		rtpTs += 180 // 90 kHz clock advanced over the 2 ms send interval
+		pcrBase += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	s := tr.Stats()
+	require.EqualValues(t, n, s.Packets)
+	require.Len(t, s.Clocks, 2, "RTP source correlates both the RTP timestamp and the PCR clock")
+
+	clocks := map[string]ClockStats{}
+	for _, c := range s.Clocks {
+		clocks[c.Source] = c
+	}
+	require.Contains(t, clocks, "rtp")
+	require.Contains(t, clocks, "pcr")
+	require.Greater(t, clocks["rtp"].Samples, uint64(0), "RTP timestamp samples must be correlated")
+	require.Greater(t, clocks["pcr"].Samples, uint64(0), "PCR samples must be correlated")
+	require.EqualValues(t, n, clocks["rtp"].PacketCount, "rtp ClockStats tracks its own packet count")
+}
+
+// TestMediaTracker_MultiProgramPCR drives a multi-program transport stream and verifies that both PCR-bearing PIDs
+// are correlated independently, mirroring content-fabric's TestProbe_MultiProgramPCR.
+func TestMediaTracker_MultiProgramPCR(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+
+	base := utc.Now()
+	pcrA, pcrB := uint64(1_000_000), uint64(50_000_000)
+	const n = 20
+	for i := 0; i < n; i++ {
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), tsDatagramTwoPrograms(pcrA, pcrB))
+		step := mpegts.DurationToPcr(2 * time.Millisecond)
+		pcrA += step
+		pcrB += step
+	}
+
+	s := tr.Stats()
+	require.Len(t, s.Clocks, 2, "each PCR-bearing PID is correlated independently")
+
+	byPid := map[int]ClockStats{}
+	for _, c := range s.Clocks {
+		require.Equal(t, "pcr", c.Source)
+		byPid[c.Pid] = c
+	}
+	require.Contains(t, byPid, 0x100)
+	require.Contains(t, byPid, 0x200)
+	require.Greater(t, byPid[0x100].Samples, uint64(0))
+	require.Greater(t, byPid[0x200].Samples, uint64(0))
+
+	require.NotNil(t, s.Ts, "TS program stats must be collected")
+	require.Greater(t, s.Ts.PacketCount, 0)
+	tsPids := map[int]int{}
+	for _, st := range s.Ts.Streams {
+		tsPids[st.Pid] = st.PacketCount
+	}
+	require.Contains(t, tsPids, 0x100)
+	require.Contains(t, tsPids, 0x200)
+
+	// the synthetic sender's fixed continuity counter yields errors, reported by PID
+	ccByPid := map[int]int{}
+	for _, e := range s.Errors.ByPid {
+		ccByPid[e.Pid] = e.CcErrors
+	}
+	require.Contains(t, ccByPid, 0x100)
+	require.Contains(t, ccByPid, 0x200)
+	require.Greater(t, s.Errors.Total, 0)
+	require.Greater(t, s.Errors.CcErrors, 0)
+}
+
+// TestMediaTracker_PeriodStats verifies that PeriodStats reports only the current window and resets it, while Stats
+// keeps reporting the cumulative totals.
+func TestMediaTracker_PeriodStats(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+
+	base := utc.Now()
+	var pcr uint64 = 1_000_000
+	for i := 0; i < 5; i++ {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	p1 := tr.PeriodStats()
+	require.EqualValues(t, 5, p1.Packets)
+	require.NotZero(t, p1.Window)
+
+	for i := 5; i < 8; i++ {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	p2 := tr.PeriodStats()
+	require.EqualValues(t, 3, p2.Packets, "period counters reset after the previous PeriodStats call")
+
+	total := tr.Stats()
+	require.EqualValues(t, 8, total.Packets, "Stats keeps reporting the cumulative total")
+}
+
+// TestMediaTracker_TrackPacket verifies that feeding the same bytes via TrackPacket (the zero-reparse entry point
+// used by a caller that already holds a decoded pktpool.Packet, e.g. avpipe) produces the same aggregate stats as
+// feeding them via TrackDatagram (the raw-bytes entry point used by the probe CLI).
+func TestMediaTracker_TrackPacket(t *testing.T) {
+	base := utc.Now()
+	var seq uint16
+	var rtpTs uint32 = 1_000
+	var pcrBase uint64 = 1_000_000
+
+	datagrams := make([][]byte, 0, 10)
+	for i := 0; i < 10; i++ {
+		dg, _ := tsDatagramWithPCR(pcrBase)
+		datagrams = append(datagrams, rtpWrap(seq, rtpTs, dg))
+		seq++
+		rtpTs += 180
+		pcrBase += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	// The synthetic fixture reuses a fixed continuity counter, so from the second datagram onward both trackers
+	// legitimately return a continuity-counter error; what matters here is that they agree (checked below via the
+	// aggregated Ts.ErrorCount), not that either returns nil.
+	viaDatagram := NewMediaTracker("test", Config{Rtp: true})
+	for i, dg := range datagrams {
+		_ = viaDatagram.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+	}
+
+	viaPacket := NewMediaTracker("test", Config{Rtp: true})
+	for i, dg := range datagrams {
+		p := pktpool.NewPacket(0, len(dg))
+		require.NoError(t, p.From(dg))
+		_ = viaPacket.TrackPacket(base.Add(time.Duration(i)*2*time.Millisecond), p)
+	}
+
+	sd, sp := viaDatagram.Stats(), viaPacket.Stats()
+	require.Equal(t, sd.Packets, sp.Packets)
+	require.Equal(t, sd.Bytes, sp.Bytes)
+	require.Equal(t, len(sd.Clocks), len(sp.Clocks))
+	for i := range sd.Clocks {
+		require.Equal(t, sd.Clocks[i].Source, sp.Clocks[i].Source)
+		require.Equal(t, sd.Clocks[i].Samples, sp.Clocks[i].Samples)
+	}
+	require.Equal(t, sd.Ts.PacketCount, sp.Ts.PacketCount)
+	require.Equal(t, sd.Ts.ErrorCount, sp.Ts.ErrorCount)
+}
+
+// TestMediaTracker_SmallPacketsDropped verifies that undersized datagrams are dropped and counted, distinguishing a
+// misdirected RTCP packet from a plain malformed one - logic ported from avpipe's MpegtsPacketProcessor.
+func TestMediaTracker_SmallPacketsDropped(t *testing.T) {
+	tr := NewMediaTracker("test", Config{Rtp: true})
+
+	// too small to be RTP-wrapped MPEG-TS, and not RTCP-shaped
+	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 0x00}))
+	s := tr.Stats()
+	require.EqualValues(t, 1, s.Errors.SmallPacketsDropped)
+	require.EqualValues(t, 0, s.Errors.RtcpPacketsDropped)
+
+	// small and RTCP-shaped (payload type 200 = SR)
+	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 200}))
+	s = tr.Stats()
+	require.EqualValues(t, 2, s.Errors.SmallPacketsDropped)
+	require.EqualValues(t, 1, s.Errors.RtcpPacketsDropped)
+}
+
+// TestMediaTracker_LongHeaders verifies that an RTP header longer than the expected 12 bytes (an extension-bearing
+// packet) is counted, both via TrackDatagram and TrackPacket.
+func TestMediaTracker_LongHeaders(t *testing.T) {
+	dg, _ := tsDatagramWithPCR(1_000_000)
+	pkt := rtpWrapWithExtension(0, 1000, dg)
+
+	tr := NewMediaTracker("test", Config{Rtp: true})
+	require.NoError(t, tr.TrackDatagram(utc.Now(), pkt))
+	require.EqualValues(t, 1, tr.Stats().Errors.LongHeaders)
+
+	tr2 := NewMediaTracker("test", Config{Rtp: true})
+	p := pktpool.NewPacket(0, len(pkt))
+	require.NoError(t, p.From(pkt))
+	require.NoError(t, tr2.TrackPacket(utc.Now(), p))
+	require.EqualValues(t, 1, tr2.Stats().Errors.LongHeaders)
+}
+
+// TestMediaTracker_FaultyPaddingPackets verifies that a null-PID packet whose payload is not valid 0xFF padding is
+// counted - logic ported from avpipe's MpegtsPacketProcessor/RemoveTsPadding.
+func TestMediaTracker_FaultyPaddingPackets(t *testing.T) {
+	dg, _ := tsDatagramWithPCR(1_000_000)
+	// corrupt one byte of the trailing null packet's payload (offset: 1 PCR packet + 3 null packets in, byte 5 of
+	// the payload)
+	dg[packet.PacketSize*4+5] = 0x00
+
+	tr := NewMediaTracker("test", Config{})
+	require.NoError(t, tr.TrackDatagram(utc.Now(), dg))
+	require.EqualValues(t, 1, tr.Stats().Errors.FaultyPaddingPackets)
+}
+
+// TestMediaTracker_NumWraps verifies that a true PCR wraparound (as opposed to a small backward jump from
+// reordering) is counted - logic ported from avpipe's MpegtsPacketProcessor.updatePCR.
+func TestMediaTracker_NumWraps(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+	base := utc.Now()
+
+	// approach MaxPCR, then wrap back down close to 0. As in the other multi-call tests, the synthetic fixture's
+	// fixed continuity counter legitimately yields a continuity-counter error from the second datagram onward.
+	near := mpegts.MaxPCR - mpegts.DurationToPcr(4*time.Millisecond)
+	dg1, _ := tsDatagramWithPCR(near)
+	_ = tr.TrackDatagram(base, dg1)
+	dg2, _ := tsDatagramWithPCR(near + mpegts.DurationToPcr(2*time.Millisecond))
+	_ = tr.TrackDatagram(base.Add(2*time.Millisecond), dg2)
+	wrapped := (near + mpegts.DurationToPcr(4*time.Millisecond)) % (mpegts.MaxPCR + 1)
+	dg3, _ := tsDatagramWithPCR(wrapped)
+	_ = tr.TrackDatagram(base.Add(4*time.Millisecond), dg3)
+
+	s := tr.Stats()
+	require.Len(t, s.Clocks, 1)
+	require.EqualValues(t, 1, s.Clocks[0].NumWraps)
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Fixtures below are ported from content-fabric's qfab/cmd/media/probe/probe_test.go.
+
+// rtpWrap prepends a minimal 12-byte RTP header (payload type 33 = MP2T) carrying the given sequence number and
+// timestamp to the given MPEG-TS payload.
+func rtpWrap(seq uint16, ts uint32, payload []byte) []byte {
+	pkt := make([]byte, 12+len(payload))
+	pkt[0] = 0x80 // version 2, no padding/extension/CSRC
+	pkt[1] = 33   // payload type MP2T
+	binary.BigEndian.PutUint16(pkt[2:], seq)
+	binary.BigEndian.PutUint32(pkt[4:], ts)
+	binary.BigEndian.PutUint32(pkt[8:], 0xdeadbeef) // arbitrary SSRC
+	copy(pkt[12:], payload)
+	return pkt
+}
+
+// rtpWrapWithExtension is rtpWrap with a minimal (4-byte) one-byte-header RTP extension, so the header consumes 16
+// bytes instead of 12.
+func rtpWrapWithExtension(seq uint16, ts uint32, payload []byte) []byte {
+	pkt := make([]byte, 16+len(payload))
+	pkt[0] = 0x90 // version 2, extension bit set
+	pkt[1] = 33
+	binary.BigEndian.PutUint16(pkt[2:], seq)
+	binary.BigEndian.PutUint32(pkt[4:], ts)
+	binary.BigEndian.PutUint32(pkt[8:], 0xdeadbeef)
+	binary.BigEndian.PutUint16(pkt[12:], 0xbede) // one-byte-header extension profile
+	binary.BigEndian.PutUint16(pkt[14:], 0)      // 0 extension words
+	copy(pkt[16:], payload)
+	return pkt
+}
+
+// tsDatagramWithPCR builds a 7-packet TS datagram whose first packet (PID 0x100) carries the given PCR value (in
+// 27 MHz units). The remaining packets are null packets. Returns the datagram bytes and the PCR value that
+// mpegts.ExtractPCR will report for the first packet.
+func tsDatagramWithPCR(pcr uint64) (datagram []byte, reported uint64) {
+	datagram = append(datagram, tsPcrPacket(0x100, pcr)...)
+	for i := 0; i < 6; i++ {
+		datagram = append(datagram, tsNullPacket()...)
+	}
+	return datagram, pcr
+}
+
+// tsDatagramTwoPrograms builds a datagram emulating a two-program transport stream: two PCR-bearing packets on PIDs
+// 0x100 and 0x200 (one per program) followed by null packets.
+func tsDatagramTwoPrograms(pcrA, pcrB uint64) []byte {
+	var datagram []byte
+	datagram = append(datagram, tsPcrPacket(0x100, pcrA)...)
+	datagram = append(datagram, tsPcrPacket(0x200, pcrB)...)
+	for i := 0; i < 5; i++ {
+		datagram = append(datagram, tsNullPacket()...)
+	}
+	return datagram
+}
+
+// tsPcrPacket crafts a 188-byte TS packet on the given PID with an adaptation field carrying the PCR. The PCR value
+// is in 27 MHz units and is split into the 33-bit @90 kHz base and 9-bit @27 MHz extension per ISO 13818-1.
+func tsPcrPacket(pid int, pcr uint64) []byte {
+	base := pcr / 300
+	ext := pcr % 300
+
+	pkt := make([]byte, packet.PacketSize)
+	pkt[0] = packet.SyncByte
+	pkt[1] = byte(pid>>8) & 0x1f
+	pkt[2] = byte(pid)
+	pkt[3] = 0x30 // adaptation field + payload, continuity counter 0
+	pkt[4] = 7    // adaptation field length: 1 flags byte + 6 PCR bytes
+	pkt[5] = 0x10 // PCR flag
+	pkt[6] = byte(base >> 25)
+	pkt[7] = byte(base >> 17)
+	pkt[8] = byte(base >> 9)
+	pkt[9] = byte(base >> 1)
+	pkt[10] = byte(base<<7)&0x80 | 0x7e | byte((ext>>8)&0x01)
+	pkt[11] = byte(ext)
+	for i := 12; i < packet.PacketSize; i++ {
+		pkt[i] = 0xff
+	}
+	return pkt
+}
+
+func tsNullPacket() []byte {
+	pkt := make([]byte, packet.PacketSize)
+	pkt[0] = packet.SyncByte
+	pkt[1] = 0x1f // PID 0x1fff (null)
+	pkt[2] = 0xff
+	pkt[3] = 0x10 // payload only, continuity counter 0
+	for i := 4; i < packet.PacketSize; i++ {
+		pkt[i] = 0xff
+	}
+	return pkt
+}

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -227,13 +227,13 @@ func TestMediaTracker_SmallPacketsDropped(t *testing.T) {
 	tr := NewMediaTracker("test", Config{Rtp: true})
 
 	// too small to be RTP-wrapped MPEG-TS, and not RTCP-shaped
-	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 0x00}))
+	require.ErrorIs(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 0x00}), ErrDropped)
 	s := tr.Stats()
 	require.EqualValues(t, 1, s.Errors.SmallPacketsDropped)
 	require.EqualValues(t, 0, s.Errors.RtcpPacketsDropped)
 
 	// small and RTCP-shaped (payload type 200 = SR)
-	require.NoError(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 200}))
+	require.ErrorIs(t, tr.TrackDatagram(utc.Now(), []byte{0x80, 200}), ErrDropped)
 	s = tr.Stats()
 	require.EqualValues(t, 2, s.Errors.SmallPacketsDropped)
 	require.EqualValues(t, 1, s.Errors.RtcpPacketsDropped)

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -398,6 +398,120 @@ func TestMediaTracker_TrackDatagram_Unbounded(t *testing.T) {
 	require.EqualValues(t, 1000, tr.Stats().Ts.PacketCount)
 }
 
+// TestMediaTracker_Snapshot_ReusesSlices verifies that calling Snapshot repeatedly with the same destination reuses
+// the Clocks slice, each ClockStats.Gaps slice, and Errors.ByPid's backing array instead of reallocating, as long as
+// the shape (RTP + PCR-bearing PIDs, retained gaps) is stable across calls - the common case for a live stream.
+func TestMediaTracker_Snapshot_ReusesSlices(t *testing.T) {
+	tr := NewMediaTracker("test", Config{Rtp: true})
+	base := utc.Now()
+	var seq uint16
+	var rtpTs uint32 = 1_000
+	var pcr uint64 = 1_000_000
+
+	track := func() {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(base, rtpWrap(seq, rtpTs, dg))
+		seq++
+		rtpTs += 180
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+		base = base.Add(2 * time.Millisecond)
+	}
+	for i := 0; i < 3; i++ {
+		track()
+	}
+
+	snap := &Stats{}
+	tr.Snapshot(snap, true, base, SnapshotOptions{})
+	require.Len(t, snap.Clocks, 2)
+	clocksArray := snap.Clocks
+	gapsArray := snap.Clocks[0].Gaps // rtp entry always at index 0 when Config.Rtp is set
+
+	for i := 0; i < 3; i++ {
+		track()
+	}
+	tr.Snapshot(snap, true, base, SnapshotOptions{})
+	require.Len(t, snap.Clocks, 2)
+	require.Same(t, &clocksArray[0], &snap.Clocks[0], "Clocks' backing array is reused, not reallocated")
+	if len(snap.Clocks[0].Gaps) > 0 && len(gapsArray) > 0 {
+		require.Same(t, &gapsArray[0], &snap.Clocks[0].Gaps[0], "Gaps' backing array is reused, not reallocated")
+	}
+}
+
+// TestMediaTracker_Snapshot_PeriodResets verifies Snapshot(total=false) resets the period window exactly like
+// PeriodStats does - the defining behavior a reuse-minded caller (e.g. content-fabric's probe command) still needs
+// when it calls Snapshot directly instead of PeriodStats.
+func TestMediaTracker_Snapshot_PeriodResets(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+	base := utc.Now()
+	var pcr uint64 = 1_000_000
+	for i := 0; i < 5; i++ {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	snap := &Stats{}
+	tr.Snapshot(snap, false, base, SnapshotOptions{})
+	require.EqualValues(t, 5, snap.Packets)
+
+	for i := 5; i < 8; i++ {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	tr.Snapshot(snap, false, base, SnapshotOptions{})
+	require.EqualValues(t, 3, snap.Packets, "period counters reset after the previous Snapshot(total=false) call")
+
+	require.EqualValues(t, 8, tr.Stats().Packets, "Stats keeps reporting the cumulative total")
+}
+
+// TestMediaTracker_Snapshot_SkipTs verifies SkipTs leaves Ts nil and Errors.ByPid empty, while Errors.Total/CcErrors
+// still populate correctly from mpegts.TsStreamTracker's cheap running totals.
+func TestMediaTracker_Snapshot_SkipTs(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+	base := utc.Now()
+	dg, _ := tsDatagramWithPCR(1_000_000)
+	_ = tr.TrackDatagram(base, dg)
+	// A second datagram on the same fixed continuity counter legitimately trips a CC error (as in other tests).
+	_ = tr.TrackDatagram(base.Add(2*time.Millisecond), dg)
+
+	full := &Stats{}
+	tr.Snapshot(full, true, base, SnapshotOptions{})
+	require.NotNil(t, full.Ts)
+	require.NotZero(t, full.Errors.CcErrors)
+	require.NotEmpty(t, full.Errors.ByPid)
+
+	lean := &Stats{}
+	tr.Snapshot(lean, true, base, SnapshotOptions{SkipTs: true})
+	require.Nil(t, lean.Ts)
+	require.Empty(t, lean.Errors.ByPid)
+	require.Equal(t, full.Errors.Total, lean.Errors.Total, "Total is available cheaply either way")
+	require.Equal(t, full.Errors.CcErrors, lean.Errors.CcErrors, "CcErrors is available cheaply either way")
+}
+
+// TestMediaTracker_Stats_CopyInto verifies CopyInto produces a deeply independent copy - mutating the source via a
+// tracker's next Snapshot call (simulating reuse) must not affect a destination copied out earlier.
+func TestMediaTracker_Stats_CopyInto(t *testing.T) {
+	tr := NewMediaTracker("test", Config{Rtp: true})
+	base := utc.Now()
+	dg, _ := tsDatagramWithPCR(1_000_000)
+	_ = tr.TrackDatagram(base, rtpWrap(0, 1000, dg))
+	_ = tr.TrackDatagram(base.Add(2*time.Millisecond), rtpWrap(1, 1180, dg))
+
+	src := tr.Stats()
+	dst := &Stats{}
+	src.CopyInto(dst)
+	require.Equal(t, src.Packets, dst.Packets)
+	require.Len(t, dst.Clocks, len(src.Clocks))
+	require.NotSame(t, &src.Clocks[0], &dst.Clocks[0])
+
+	// Advance the tracker and re-snapshot into src (as a caller reusing src via Snapshot would) - dst must not see it.
+	_ = tr.TrackDatagram(base.Add(4*time.Millisecond), rtpWrap(2, 1360, dg))
+	tr.Snapshot(src, true, base.Add(4*time.Millisecond), SnapshotOptions{})
+	require.NotEqual(t, src.Packets, dst.Packets, "dst must not have changed just because src was refreshed")
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 // Fixture helpers below build synthetic RTP/MPEG-TS datagrams for the tests above.
 

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -16,8 +16,8 @@ import (
 )
 
 // TestClockCorrelator_Drift feeds a perfectly regular media clock that runs 100 ppm faster than wall clock and
-// verifies the estimated drift and skew. Inputs are exact, so the assertions are tight. Ported from
-// content-fabric's qfab/cmd/media/probe/probe_test.go to document the sign convention this package inherited.
+// verifies the estimated drift and skew. Inputs are exact, so the assertions are tight; it documents the sign
+// convention clockCorrelator uses.
 func TestClockCorrelator_Drift(t *testing.T) {
 	c := newClockCorrelator("rtp", rtp.TicksToDuration) // RTP: 90 kHz clock
 
@@ -37,7 +37,7 @@ func TestClockCorrelator_Drift(t *testing.T) {
 }
 
 // TestMediaTracker_RawTs drives a raw (non-RTP) MPEG-TS source and verifies the aggregate stats and the PCR
-// correlation, mirroring content-fabric's TestProbe_UDP.
+// correlation.
 func TestMediaTracker_RawTs(t *testing.T) {
 	tr := NewMediaTracker("test", Config{})
 
@@ -64,7 +64,7 @@ func TestMediaTracker_RawTs(t *testing.T) {
 }
 
 // TestMediaTracker_RTP drives an RTP-wrapped MPEG-TS source and verifies that both the RTP-timestamp and PCR clocks
-// are correlated, mirroring content-fabric's TestProbe_RTP.
+// are correlated.
 func TestMediaTracker_RTP(t *testing.T) {
 	tr := NewMediaTracker("test", Config{Rtp: true})
 
@@ -99,7 +99,7 @@ func TestMediaTracker_RTP(t *testing.T) {
 }
 
 // TestMediaTracker_MultiProgramPCR drives a multi-program transport stream and verifies that both PCR-bearing PIDs
-// are correlated independently, mirroring content-fabric's TestProbe_MultiProgramPCR.
+// are correlated independently.
 func TestMediaTracker_MultiProgramPCR(t *testing.T) {
 	tr := NewMediaTracker("test", Config{})
 
@@ -177,8 +177,8 @@ func TestMediaTracker_PeriodStats(t *testing.T) {
 }
 
 // TestMediaTracker_TrackPacket verifies that feeding the same bytes via TrackPacket (the zero-reparse entry point
-// used by a caller that already holds a decoded pktpool.Packet, e.g. avpipe) produces the same aggregate stats as
-// feeding them via TrackDatagram (the raw-bytes entry point used by the probe CLI).
+// used by a caller that already holds a decoded pktpool.Packet) produces the same aggregate stats as feeding them
+// via TrackDatagram (the raw-bytes entry point used by a caller with no pktpool dependency).
 func TestMediaTracker_TrackPacket(t *testing.T) {
 	base := utc.Now()
 	var seq uint16
@@ -291,8 +291,115 @@ func TestMediaTracker_NumWraps(t *testing.T) {
 	require.EqualValues(t, 1, s.Clocks[0].NumWraps)
 }
 
+// TestMediaTracker_ParityMalformedInputs feeds a battery of malformed/edge-case datagrams through both TrackDatagram
+// and TrackPacket, asserting they produce identical ErrorStats. This is a regression test for a real divergence
+// found when the two entry points had independent parsing paths: TrackDatagram used raw pion (rtp.ParsePacket),
+// which never validates the RTP version field, while TrackPacket explicitly rejected a bad version - so a
+// malformed-version datagram was silently accepted (and polluted clock stats) via TrackDatagram while being
+// correctly rejected via TrackPacket. Both entry points now share trackLocked, closing the gap by construction.
+func TestMediaTracker_ParityMalformedInputs(t *testing.T) {
+	tsOK, _ := tsDatagramWithPCR(1_000_000)
+
+	tsTruncated := append([]byte{}, tsOK[:189]...) // 1 full TS packet + 1 stray byte: not a multiple of 188
+
+	cases := []struct {
+		name string
+		dg   []byte
+	}{
+		{"bad RTP version", rtpWrapVersion(1, 0, 1000, tsOK)},
+		{"TS payload not multiple of 188", rtpWrap(0, 1000, tsTruncated)},
+		{"undersized, not RTCP-shaped", []byte{0x80, 0x00}},
+		{"undersized, RTCP-shaped", []byte{0x80, 200}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			trDg := NewMediaTracker("test", Config{Rtp: true})
+			errDg := trDg.TrackDatagram(utc.Now(), c.dg)
+
+			trPkt := NewMediaTracker("test", Config{Rtp: true})
+			p := pktpool.NewPacket(0, len(c.dg))
+			require.NoError(t, p.From(c.dg))
+			errPkt := trPkt.TrackPacket(utc.Now(), p)
+
+			require.Equal(t, errDg == nil, errPkt == nil, "error-or-not must agree between TrackDatagram and TrackPacket")
+			require.Equal(t, trDg.Stats().Errors, trPkt.Stats().Errors)
+		})
+	}
+}
+
+// TestMediaTracker_BadSyncByte verifies that a corrupted TS sync byte mid-datagram is handled identically by
+// TrackDatagram and TrackPacket, and that it only drops the one bad packet from the PCR/padding scan (not the rest
+// of the datagram) - a second divergence found during the same review: TrackPacket's scanTsPackets had no sync-byte
+// check at all before this fix, unlike TrackDatagram's (now-deleted) scanTsBytes. Note tsTracker.TrackPackets
+// independently flags the same bad packet via CheckErrors (sync-byte validation is one of its checks), so both
+// TrackDatagram and TrackPacket still return an error here regardless of the scanOneTsPacket fix below - what this
+// test locks in is that the PCR scan itself skips only the one bad packet and keeps processing the rest.
+func TestMediaTracker_BadSyncByte(t *testing.T) {
+	base := utc.Now()
+	pcr := uint64(1_000_000)
+	nextDatagram := func(corrupt bool) []byte {
+		dg, _ := tsDatagramWithPCR(pcr) // 7 TS packets, the first (PID 0x100) carries the PCR
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+		if corrupt {
+			dg[packet.PacketSize*3] = 0x00 // corrupt the sync byte of the 4th packet only
+		}
+		return rtpWrap(0, 1000, dg)
+	}
+
+	// Two clean datagrams first, to establish the PCR correlator's reference and get one real sample (sample()
+	// consumes its first call just arming the reference - see clockCorrelator.sample), then a third with a
+	// corrupted sync byte.
+	dgs := [][]byte{nextDatagram(false), nextDatagram(false), nextDatagram(true)}
+
+	trDg := NewMediaTracker("test", Config{Rtp: true})
+	var errDg error
+	for i, dg := range dgs {
+		errDg = trDg.TrackDatagram(base.Add(time.Duration(i)*2*time.Millisecond), dg)
+	}
+
+	trPkt := NewMediaTracker("test", Config{Rtp: true})
+	var errPkt error
+	for i, dg := range dgs {
+		p := pktpool.NewPacket(0, len(dg))
+		require.NoError(t, p.From(dg))
+		errPkt = trPkt.TrackPacket(base.Add(time.Duration(i)*2*time.Millisecond), p)
+	}
+
+	require.Error(t, errDg, "tsTracker.TrackPackets flags the bad sync byte via CheckErrors")
+	require.Error(t, errPkt)
+
+	for _, tr := range []MediaTracker{trDg, trPkt} {
+		s := tr.Stats()
+		var pcrClock *ClockStats
+		for i := range s.Clocks {
+			if s.Clocks[i].Source == "pcr" {
+				pcrClock = &s.Clocks[i]
+			}
+		}
+		require.NotNil(t, pcrClock)
+		require.EqualValues(t, 1, pcrClock.ParseErrors, "exactly the one corrupted packet is counted")
+		require.EqualValues(t, 2, pcrClock.Samples,
+			"the PCR-bearing packet in the 3rd (corrupted) datagram is still processed despite the bad packet elsewhere in it")
+	}
+}
+
+// TestMediaTracker_TrackDatagram_Unbounded verifies TrackDatagram accepts a datagram far larger than any fixed
+// buffer capacity would allow - the property RawPacket gives "for free" (no backing buffer, unlike the
+// Wrap-on-Packet alternative considered and rejected during design, which would have needed a capacity limit).
+func TestMediaTracker_TrackDatagram_Unbounded(t *testing.T) {
+	var large []byte
+	for i := 0; i < 1000; i++ { // ~188KB, well beyond any typical UDP/RTP datagram
+		large = append(large, tsNullPacket()...)
+	}
+
+	tr := NewMediaTracker("test", Config{})
+	require.NoError(t, tr.TrackDatagram(utc.Now(), large))
+	require.EqualValues(t, 1000, tr.Stats().Ts.PacketCount)
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
-// Fixtures below are ported from content-fabric's qfab/cmd/media/probe/probe_test.go.
+// Fixture helpers below build synthetic RTP/MPEG-TS datagrams for the tests above.
 
 // rtpWrap prepends a minimal 12-byte RTP header (payload type 33 = MP2T) carrying the given sequence number and
 // timestamp to the given MPEG-TS payload.
@@ -304,6 +411,13 @@ func rtpWrap(seq uint16, ts uint32, payload []byte) []byte {
 	binary.BigEndian.PutUint32(pkt[4:], ts)
 	binary.BigEndian.PutUint32(pkt[8:], 0xdeadbeef) // arbitrary SSRC
 	copy(pkt[12:], payload)
+	return pkt
+}
+
+// rtpWrapVersion is rtpWrap with an explicit (possibly invalid) RTP version instead of the fixed version 2.
+func rtpWrapVersion(version byte, seq uint16, ts uint32, payload []byte) []byte {
+	pkt := rtpWrap(seq, ts, payload)
+	pkt[0] = (pkt[0] &^ 0xC0) | (version << 6)
 	return pkt
 }
 

--- a/media/tracker/tracker_test.go
+++ b/media/tracker/tracker_test.go
@@ -269,6 +269,28 @@ func TestMediaTracker_FaultyPaddingPackets(t *testing.T) {
 	require.EqualValues(t, 1, tr.Stats().Errors.FaultyPaddingPackets)
 }
 
+// TestMediaTracker_ValidPadding_AdaptationField is a regression test for isValidPadding unconditionally treating
+// bytes 4..187 as payload: a null-PID packet is not required to be payload-only (adaptation_field_control 01) - it
+// may legally carry an adaptation field too (11), in which case the real payload starts later than byte 4.
+func TestMediaTracker_ValidPadding_AdaptationField(t *testing.T) {
+	valid := append(tsPcrPacket(0x100, 1_000_000), tsNullPacketWithAdaptationField()...)
+	valid = append(valid, tsNullPacket()...)
+
+	tr := NewMediaTracker("test", Config{})
+	require.NoError(t, tr.TrackDatagram(utc.Now(), valid))
+	require.EqualValues(t, 0, tr.Stats().Errors.FaultyPaddingPackets,
+		"a well-formed adaptation-field-bearing null packet must not be flagged as faulty")
+
+	corrupted := append(tsPcrPacket(0x100, 1_000_000), tsNullPacketWithAdaptationField()...)
+	corrupted[packet.PacketSize+6] = 0x00 // corrupt the first payload byte, after the adaptation field
+	corrupted = append(corrupted, tsNullPacket()...)
+
+	tr2 := NewMediaTracker("test", Config{})
+	require.NoError(t, tr2.TrackDatagram(utc.Now(), corrupted))
+	require.EqualValues(t, 1, tr2.Stats().Errors.FaultyPaddingPackets,
+		"corruption after the adaptation field must still be detected")
+}
+
 // TestMediaTracker_NumWraps verifies that a true PCR wraparound (as opposed to a small backward jump from
 // reordering) is counted - logic ported from avpipe's MpegtsPacketProcessor.updatePCR.
 func TestMediaTracker_NumWraps(t *testing.T) {
@@ -466,6 +488,55 @@ func TestMediaTracker_Snapshot_PeriodResets(t *testing.T) {
 	require.EqualValues(t, 8, tr.Stats().Packets, "Stats keeps reporting the cumulative total")
 }
 
+// TestMediaTracker_Snapshot_TotalElapsedUsesCallerNow is a regression test for a bug where the total-path branch of
+// Snapshot read the real wall clock (utc.Since(t.start)) instead of the caller-supplied now, breaking determinism
+// for any caller/test passing a synthetic now - and silently diverging from the period branch a few lines below,
+// which already used now correctly.
+func TestMediaTracker_Snapshot_TotalElapsedUsesCallerNow(t *testing.T) {
+	tr := NewMediaTracker("test", Config{})
+	start := utc.Now()
+	dg, _ := tsDatagramWithPCR(1_000_000)
+	_ = tr.TrackDatagram(start, dg)
+
+	// A synthetic "now" far from the real wall clock - only correct if Snapshot actually uses it.
+	syntheticNow := start.Add(time.Hour)
+	snap := &Stats{}
+	tr.Snapshot(snap, true, syntheticNow, SnapshotOptions{})
+
+	require.Equal(t, duration.Spec(time.Hour).RoundTo(2), snap.Elapsed,
+		"Elapsed must be derived from the caller-supplied now, not the real wall clock")
+}
+
+// TestMediaTracker_Snapshot_PeriodOutagesReset verifies that a period snapshot's Outages reflects only the current
+// period, resetting after each period snapshot like Packets/Bytes/Ipd already do - a regression test for outages
+// previously always being reported from the cumulative (never-reset) counters even for total=false.
+func TestMediaTracker_Snapshot_PeriodOutagesReset(t *testing.T) {
+	tr := NewMediaTracker("test", Config{OutageThreshold: 10 * time.Millisecond})
+	base := utc.Now()
+	var pcr uint64 = 1_000_000
+
+	track := func(at utc.UTC) {
+		dg, _ := tsDatagramWithPCR(pcr)
+		_ = tr.TrackDatagram(at, dg)
+		pcr += mpegts.DurationToPcr(2 * time.Millisecond)
+	}
+
+	track(base)
+	track(base.Add(20 * time.Millisecond)) // gap >= OutageThreshold: one outage
+
+	p1 := tr.PeriodStats()
+	require.EqualValues(t, 1, p1.Outages.Count, "period reports the outage that happened during this period")
+	require.NotZero(t, p1.Outages.TotalMs)
+
+	track(base.Add(21 * time.Millisecond)) // 1ms gap: below OutageThreshold, no new outage
+
+	p2 := tr.PeriodStats()
+	require.Zero(t, p2.Outages.Count, "period outages reset after the previous PeriodStats call")
+	require.Zero(t, p2.Outages.TotalMs)
+
+	require.EqualValues(t, 1, tr.Stats().Outages.Count, "total snapshot keeps reporting the cumulative outage count")
+}
+
 // TestMediaTracker_Snapshot_SkipTs verifies SkipTs leaves Ts nil and Errors.ByPid empty, while Errors.Total/CcErrors
 // still populate correctly from mpegts.TsStreamTracker's cheap running totals.
 func TestMediaTracker_Snapshot_SkipTs(t *testing.T) {
@@ -606,6 +677,23 @@ func tsNullPacket() []byte {
 	pkt[3] = 0x10 // payload only, continuity counter 0
 	for i := 4; i < packet.PacketSize; i++ {
 		pkt[i] = 0xff
+	}
+	return pkt
+}
+
+// tsNullPacketWithAdaptationField builds a null-PID (0x1fff) TS packet carrying both an adaptation field and a
+// payload (adaptation_field_control 11) - a spec-legal but unusual shape for a null packet, used to verify
+// isValidPadding locates the payload after the adaptation field rather than assuming it always starts at byte 4.
+func tsNullPacketWithAdaptationField() []byte {
+	pkt := make([]byte, packet.PacketSize)
+	pkt[0] = packet.SyncByte
+	pkt[1] = 0x1f // PID 0x1fff (null)
+	pkt[2] = 0xff
+	pkt[3] = 0x30 // adaptation field + payload, continuity counter 0
+	pkt[4] = 1    // adaptation field length: 1 flags byte, no PCR/OPCR/splicing/private data/extension
+	pkt[5] = 0x00 // flags: none set
+	for i := 6; i < packet.PacketSize; i++ {
+		pkt[i] = 0xff // payload: valid padding
 	}
 	return pkt
 }

--- a/media/tracker/util.go
+++ b/media/tracker/util.go
@@ -1,0 +1,35 @@
+package tracker
+
+import (
+	"math"
+	"time"
+
+	"github.com/eluv-io/common-go/util/statsutil"
+)
+
+// rates computes the packet and bit rate for the given counts over the given duration.
+func rates(packets, bytes uint64, dur time.Duration) (pps, bps float64) {
+	secs := dur.Seconds()
+	if secs <= 0 {
+		return 0, 0
+	}
+	return float64(packets) / secs, float64(bytes) * 8 / secs
+}
+
+// stddev returns the (sample) standard deviation of the collected statistics, or 0 if it is undefined.
+func stddev[T statsutil.Number](s *statsutil.Statistics[T]) float64 {
+	s.CalcVariance(true)
+	if s.Variance <= 0 {
+		return 0
+	}
+	return math.Sqrt(s.Variance)
+}
+
+// round rounds f to the given number of decimal places, mapping NaN and infinities to 0.
+func round(f float64, decimals int) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	p := math.Pow(10, float64(decimals))
+	return math.Round(f*p) / p
+}


### PR DESCRIPTION
### Summary
Extracts and generalizes content-fabric's per-stream stats/clock-correlation tracking into a new `media/tracker.MediaTracker`, so it can be shared between content-fabric's `probe` CLI and avpipe's `MpegtsPacketProcessor` instead of living as two independently-drifting implementations. Also adds a reuse-friendly `Snapshot`/`CopyInto` API to bound per-call allocations for a periodic poller, and fixes a few real bugs found while unifying the two original implementations.

### What changed

**New `media/tracker.MediaTracker`**

Composes the existing `mpegts.TsStreamTracker` and `rtp.GapDetector` rather than restructuring them:
- `TrackDatagram(data []byte)` serves a caller with only raw network bytes (the probe CLI).
- `TrackPacket(pkt *pktpool.Packet)` serves a caller that already holds a decoded packet (avpipe), reusing its already-parsed RTP/MPEG-TS layers instead of re-parsing.
- Adds stats neither original implementation tracked: PCR wrap count, RTP long-header detection, small/RTCP-shaped datagram drops, faulty-padding-packet detection.

**Reuse-friendly `Snapshot`/`CopyInto`**

`Stats()`/`PeriodStats()` allocated a full tree of new structs/slices on every call: the largest cost was `Ts *mpegts.Stats`, which walks every tracked PID and allocates a `*StreamStats` plus `*HistogramCapture` per PID — on *every* call, including `PeriodStats()`, since error totals needed the walk's output even when the caller never asked for the detailed field. For a caller polling periodically (avpipe every ~900ms, content-fabric's `probe` every period), this adds up.

- `TsStreamTracker.Snapshot(snap *Stats, full bool) *Stats`: reuses `snap.Streams` (and each entry's histogram) in place when the PID set is stable (the common case); `full=false` skips the walk entirely, backed by two new incrementally-maintained running totals.
- `MediaTracker.Snapshot(snap *Stats, total bool, now utc.UTC, opts SnapshotOptions) *Stats`: reuses `snap.Clocks`, each `ClockStats.Gaps`, and `Errors.ByPid` instead of allocating fresh ones. `SnapshotOptions.SkipTs` skips the TS walk while still populating `Errors.Total`/`CcErrors` from the cheap running totals. `total=false` folds in `PeriodStats`'s reset side effect, so a reuse-minded caller gets both in one call.
- `Stats()`/`PeriodStats()` become thin wrappers — unchanged behavior/allocation for existing callers.
- Both `Stats` types gain `CopyInto(dst)`, a deep-copy-with-destination-reuse method: once a `*Stats` is reused across calls, a caller that hands it to another goroutine/module (avpipe → content-fabric) can no longer safely retain the pointer past the next refresh. `CopyInto` lets the receiver detach an independent copy it owns outright.

**`media/io.ConnStats`/`SrtConnStats`** gain JSON tags

previously exported wholesale into dashboard-facing JSON with capitalized Go field names, inconsistent with every other stats type in the codebase. No existing consumer marshals these types today (confirmed via cross-repo grep), so this was a safe wire-format change to make now.

### Testing
Full `media/tracker`, `media/mpegts`, `media/io`, `media/pktpool` suites with `-race`. Golden-equivalence: existing fixture-based assertions in dependent repos (content-fabric's `probe`) pass unchanged against the new shared implementation.
